### PR TITLE
Removed engines setting from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,6 @@
   "main": "build/tevomaps.js",
   "author": "BRAD LARSON",
   "license": "UNLICENSED",
-  "engines": {
-    "npm": ">=8"
-  },
   "scripts": {
     "build": "webpack --progress",
     "watch": "npm run build -- --watch",


### PR DESCRIPTION
Earlier today I was trying to install this package in another project. The install failed due to an engine mismatch (this project was reporting a minimum `npm` version of `8`, which doesn't exist 🤦‍♀️). As a quick fix, I removed the setting entirely.