### PR TITLE
Fixes complex section coloring

### DIFF
--- a/examples/using-module/main.js
+++ b/examples/using-module/main.js
@@ -1,8 +1,14 @@
 import Tevomaps from '../../src/index'
-import ticketGroups from './ticket-groups-138953'
+import ticketGroups from './ticket-groups-1591449'
+
+// window.seatmap = new Tevomaps({
+//   venueId: '1947',
+//   configurationId: '5842',
+//   ticketGroups
+// }).build('map')
 
 window.seatmap = new Tevomaps({
-  venueId: '1947',
-  configurationId: '5842',
+  venueId: '896',
+  configurationId: '14341',
   ticketGroups
 }).build('map')

--- a/examples/using-module/ticket-groups-1591449.json
+++ b/examples/using-module/ticket-groups-1591449.json
@@ -1,0 +1,13517 @@
+[
+    {
+        "id": 539520858,
+        "url": "/ticket_groups/539520858",
+        "type": "event",
+        "row": "23",
+        "section": "213",
+        "quantity": 1,
+        "available_quantity": 1,
+        "wholesale_price": 187.93,
+        "eticket": false,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": "Side stage (printed on ticket)",
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-12-09T18:06:35Z",
+        "updated_at": "2019-01-02T00:39:20Z",
+        "splits": [
+            1
+        ],
+        "ticket_states": {
+            "available": 1
+        },
+        "ticket_hold_ids": [
+            "NULL"
+        ],
+        "seats": [],
+        "tickets": [
+            [
+                "available",
+                "NULL"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 187.93,
+        "format": "Physical",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 182.46,
+        "ticket_costs": [
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "K3VncWFQZXVBbXhLNWNnK1dKZTMyY2NZMHFRbnVpSU43OVEzV1RjcjM2OD0tLVkwblV1K1d4UkpFcW12cENFUGh4c2c9PQ==--a64326195d904e88297934743e1dfe0d256f950c",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "middle level corner 213"
+    },
+    {
+        "id": 535853322,
+        "url": "/ticket_groups/535853322",
+        "type": "event",
+        "row": "17",
+        "section": "214",
+        "quantity": 3,
+        "available_quantity": 3,
+        "wholesale_price": 189.83,
+        "eticket": false,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": "Side stage (printed on ticket)",
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-11-28T21:47:41Z",
+        "updated_at": "2019-01-02T00:39:19Z",
+        "splits": [
+            1,
+            3
+        ],
+        "ticket_states": {
+            "available": 3
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [],
+        "tickets": [
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 189.83,
+        "format": "Physical",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 184.3,
+        "ticket_costs": [
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "a0xNcE05bnZQVWpiTS9NN2lFVUVCcHV1ZWZkWTBnTkk0b2F3WkRLU1gxYz0tLThQZGxid25jSklOMGMyZE8vQzJVaWc9PQ==--5c5a4a4fafdff4aab82b1d424bbb342936f5cec9",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "middle level corner 214"
+    },
+    {
+        "id": 538229563,
+        "url": "/ticket_groups/538229563",
+        "type": "event",
+        "row": "BS3",
+        "section": "315",
+        "quantity": 2,
+        "available_quantity": 2,
+        "wholesale_price": 196.44,
+        "eticket": true,
+        "instant_delivery": true,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": "Side View Barstool",
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-12-06T01:48:36Z",
+        "updated_at": "2018-12-20T03:33:29Z",
+        "splits": [
+            2
+        ],
+        "ticket_states": {
+            "available": 2
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL"
+        ],
+        "seats": [],
+        "tickets": [
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 196.44,
+        "format": "Eticket",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 190.72,
+        "ticket_costs": [
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "SUV1UDJrVzlsbVVsYXZ6U2VyTk54Rm5nNXVNRU9kUHdId0gwMS9yRS9TND0tLS9kMTR5UW0wUDhZUXZTbjVrQ1lzRnc9PQ==--32203f800acde338ee400ae9f940e144bde51d78",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": true,
+        "tevo_section_name": "chase bridges 315"
+    },
+    {
+        "id": 548276472,
+        "url": "/ticket_groups/548276472",
+        "type": "event",
+        "row": "14",
+        "section": "221",
+        "quantity": 3,
+        "available_quantity": 3,
+        "wholesale_price": 199.82,
+        "eticket": false,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": "Side Stage",
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2019-01-02T19:52:04Z",
+        "updated_at": "2019-01-02T19:52:04Z",
+        "splits": [
+            1,
+            3
+        ],
+        "ticket_states": {
+            "available": 3
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [
+            "18",
+            "17",
+            "19"
+        ],
+        "tickets": [
+            [
+                "available",
+                "18"
+            ],
+            [
+                "available",
+                "17"
+            ],
+            [
+                "available",
+                "19"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 199.82,
+        "format": "Physical",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 194,
+        "ticket_costs": [
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "VjROaDNwZllQU3NSVFRudlNCWllJS3dEM0dNNFFOQkdBK3VseXNmTFdpcz0tLUJVK052THhQeFRSSG1vVzFockI0aGc9PQ==--9f56062cee9ae27e732b29f1e68d4a1573aede25",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "middle level corner 221"
+    },
+    {
+        "id": 548276476,
+        "url": "/ticket_groups/548276476",
+        "type": "event",
+        "row": "13",
+        "section": "214",
+        "quantity": 2,
+        "available_quantity": 2,
+        "wholesale_price": 200.85,
+        "eticket": false,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": "Side Stage",
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2019-01-02T19:52:04Z",
+        "updated_at": "2019-01-02T19:52:04Z",
+        "splits": [
+            2
+        ],
+        "ticket_states": {
+            "available": 2
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL"
+        ],
+        "seats": [
+            "10",
+            "9"
+        ],
+        "tickets": [
+            [
+                "available",
+                "10"
+            ],
+            [
+                "available",
+                "9"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 200.85,
+        "format": "Physical",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 195,
+        "ticket_costs": [
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "WUZFdEFzS21HclZ4RkY0NjU5M29oR0JQYlZ2TEluc2VWL0lmVzZiNlhwND0tLUlRUHpJa0dCTk5tVk9CbnVXZCtKeHc9PQ==--133b9ea55c9276f7b76e70c9f0b6d3f5a451058c",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "middle level corner 214"
+    },
+    {
+        "id": 538229562,
+        "url": "/ticket_groups/538229562",
+        "type": "event",
+        "row": "1",
+        "section": "315",
+        "quantity": 2,
+        "available_quantity": 2,
+        "wholesale_price": 207.06,
+        "eticket": true,
+        "instant_delivery": true,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": "Side View Side stage",
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-12-06T01:48:35Z",
+        "updated_at": "2018-12-20T03:33:30Z",
+        "splits": [
+            2
+        ],
+        "ticket_states": {
+            "available": 2
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL"
+        ],
+        "seats": [],
+        "tickets": [
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 207.06,
+        "format": "Eticket",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 201.03,
+        "ticket_costs": [
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "amdpMjl0YkJWVkl1V1p4Y2VXNVpCOE1hbkx2amR5N1ZqQ3NTNjdBbkxEbz0tLXJrWnNPOEcyajdZTmpLQ2dIU01FVWc9PQ==--228fed506f3fbfe813e79b2720f6c7121d92bcff",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": true,
+        "tevo_section_name": "chase bridges 315"
+    },
+    {
+        "id": 548276496,
+        "url": "/ticket_groups/548276496",
+        "type": "event",
+        "row": "11",
+        "section": "214",
+        "quantity": 6,
+        "available_quantity": 6,
+        "wholesale_price": 210.12,
+        "eticket": false,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": "Side Stage",
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2019-01-02T19:52:05Z",
+        "updated_at": "2019-01-02T19:52:05Z",
+        "splits": [
+            1,
+            2,
+            3,
+            4,
+            6
+        ],
+        "ticket_states": {
+            "available": 6
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [
+            "7",
+            "10",
+            "9",
+            "8",
+            "6",
+            "5"
+        ],
+        "tickets": [
+            [
+                "available",
+                "7"
+            ],
+            [
+                "available",
+                "10"
+            ],
+            [
+                "available",
+                "9"
+            ],
+            [
+                "available",
+                "8"
+            ],
+            [
+                "available",
+                "6"
+            ],
+            [
+                "available",
+                "5"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 210.12,
+        "format": "Physical",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 204,
+        "ticket_costs": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "Q29pc3BKMmNzT2F5Q3VQY25Ec3kzRGRXcmxFVlVlY0tkZmhaYlhNQ05rST0tLVAvZVdrM3ZKWnNId00wVVNDeEJ1MlE9PQ==--50867cc3834b0fc17d3cdcf4806c7c9e45bb6b78",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "middle level corner 214"
+    },
+    {
+        "id": 538229564,
+        "url": "/ticket_groups/538229564",
+        "type": "event",
+        "row": "2",
+        "section": "315",
+        "quantity": 3,
+        "available_quantity": 3,
+        "wholesale_price": 212.38,
+        "eticket": true,
+        "instant_delivery": true,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": "Side View",
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-12-06T01:48:36Z",
+        "updated_at": "2018-12-20T03:33:29Z",
+        "splits": [
+            1,
+            3
+        ],
+        "ticket_states": {
+            "available": 3
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [],
+        "tickets": [
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 212.38,
+        "format": "Eticket",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 206.19,
+        "ticket_costs": [
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "RjFaNE0wcWRFaHFvdHJoSnhiZHd0cms5V0lyYTVPTnNSU0ZVU3NlREJ4MD0tLVg4QUZZeklsSXF6TTRNVmI4VTJTYmc9PQ==--17e5e112e3d30ac90fd9d78c192964652060a90e",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": true,
+        "tevo_section_name": "chase bridges 315"
+    },
+    {
+        "id": 548276498,
+        "url": "/ticket_groups/548276498",
+        "type": "event",
+        "row": "7",
+        "section": "214",
+        "quantity": 6,
+        "available_quantity": 6,
+        "wholesale_price": 213.21,
+        "eticket": false,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": "Side Stage",
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2019-01-02T19:52:05Z",
+        "updated_at": "2019-01-02T19:52:05Z",
+        "splits": [
+            1,
+            2,
+            3,
+            4,
+            6
+        ],
+        "ticket_states": {
+            "available": 6
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [
+            "1",
+            "6",
+            "5",
+            "4",
+            "3",
+            "2"
+        ],
+        "tickets": [
+            [
+                "available",
+                "1"
+            ],
+            [
+                "available",
+                "6"
+            ],
+            [
+                "available",
+                "5"
+            ],
+            [
+                "available",
+                "4"
+            ],
+            [
+                "available",
+                "3"
+            ],
+            [
+                "available",
+                "2"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 213.21,
+        "format": "Physical",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 207,
+        "ticket_costs": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "ampjWmloeXpXS2llb3Y3QkhvRTQ4bVRjbTFHTTIxQUdkNldQRTRVdkhlcz0tLWEzNHR5OFlCdlFGQmFlYklFbzlRMHc9PQ==--3194d1122ee87325aa6df6017e1f0b3e0b45a192",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "middle level corner 214"
+    },
+    {
+        "id": 548276506,
+        "url": "/ticket_groups/548276506",
+        "type": "event",
+        "row": "6",
+        "section": "214",
+        "quantity": 2,
+        "available_quantity": 2,
+        "wholesale_price": 214.24,
+        "eticket": false,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": "Side Stage",
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2019-01-02T19:52:05Z",
+        "updated_at": "2019-01-02T19:52:05Z",
+        "splits": [
+            2
+        ],
+        "ticket_states": {
+            "available": 2
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL"
+        ],
+        "seats": [
+            "10",
+            "9"
+        ],
+        "tickets": [
+            [
+                "available",
+                "10"
+            ],
+            [
+                "available",
+                "9"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 214.24,
+        "format": "Physical",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 208,
+        "ticket_costs": [
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "c0RLVlBycXJTdVluR05hcEVjQlo3V2pPZmN4d0NEOGRBTVVsTjhubHI0VT0tLUpqNFZZb3hyUjY4OW05VFJ0amZ6QkE9PQ==--c4b6605664547d35f02529489d4ab5df0506513b",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "middle level corner 214"
+    },
+    {
+        "id": 548276513,
+        "url": "/ticket_groups/548276513",
+        "type": "event",
+        "row": "11",
+        "section": "221",
+        "quantity": 2,
+        "available_quantity": 2,
+        "wholesale_price": 215.27,
+        "eticket": false,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": "Side Stage",
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2019-01-02T19:52:06Z",
+        "updated_at": "2019-01-02T19:52:06Z",
+        "splits": [
+            2
+        ],
+        "ticket_states": {
+            "available": 2
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL"
+        ],
+        "seats": [
+            "11",
+            "10"
+        ],
+        "tickets": [
+            [
+                "available",
+                "11"
+            ],
+            [
+                "available",
+                "10"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 215.27,
+        "format": "Physical",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 209,
+        "ticket_costs": [
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "c3RHUGVEcnlQTWFoWmxsK2NERkM0cEQxOXVScnFGRHpkcEpjN0l2RHAzdz0tLWFXZVVva2tlbkk1MFV5VitKWkNXOUE9PQ==--4f50fc5d9ba1abc303683a5b2974f2f4440475ce",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "middle level corner 221"
+    },
+    {
+        "id": 548276485,
+        "url": "/ticket_groups/548276485",
+        "type": "event",
+        "row": "5",
+        "section": "214",
+        "quantity": 2,
+        "available_quantity": 2,
+        "wholesale_price": 215.27,
+        "eticket": false,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": "Side Stage",
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2019-01-02T19:52:04Z",
+        "updated_at": "2019-01-02T19:52:05Z",
+        "splits": [
+            2
+        ],
+        "ticket_states": {
+            "available": 2
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL"
+        ],
+        "seats": [
+            "4",
+            "3"
+        ],
+        "tickets": [
+            [
+                "available",
+                "4"
+            ],
+            [
+                "available",
+                "3"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 215.27,
+        "format": "Physical",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 209,
+        "ticket_costs": [
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "clNjSis0SkkwRnl2TFZ5bjYyN25xNWJ1U0lZbkZCYW53Z3NUZldvdm9rZz0tLVRaL2MzUy9pV3NBYnlIN3pUcjBGRlE9PQ==--993e486e7cfda2d5f894568ff4ac643ea2e1613c",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "middle level corner 214"
+    },
+    {
+        "id": 548276499,
+        "url": "/ticket_groups/548276499",
+        "type": "event",
+        "row": "16",
+        "section": "221",
+        "quantity": 2,
+        "available_quantity": 2,
+        "wholesale_price": 216.3,
+        "eticket": false,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": "Side Stage",
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2019-01-02T19:52:05Z",
+        "updated_at": "2019-01-02T19:52:05Z",
+        "splits": [
+            2
+        ],
+        "ticket_states": {
+            "available": 2
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL"
+        ],
+        "seats": [
+            "21",
+            "20"
+        ],
+        "tickets": [
+            [
+                "available",
+                "21"
+            ],
+            [
+                "available",
+                "20"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 216.3,
+        "format": "Physical",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 210,
+        "ticket_costs": [
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "eUhMQm1LLzlvamwzRDM3bUlRMHNFSi9xUnZVcHMxc1dZN1FZYXh6M29JZz0tLS9xazlPNU9pdk4rWUZzY2hWd1lUK0E9PQ==--947251b0732f91e55caf8d9f7965b2741c5e280c",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "middle level corner 221"
+    },
+    {
+        "id": 548276507,
+        "url": "/ticket_groups/548276507",
+        "type": "event",
+        "row": "10",
+        "section": "221",
+        "quantity": 2,
+        "available_quantity": 2,
+        "wholesale_price": 216.3,
+        "eticket": false,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": "Side Stage",
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2019-01-02T19:52:05Z",
+        "updated_at": "2019-01-02T19:52:05Z",
+        "splits": [
+            2
+        ],
+        "ticket_states": {
+            "available": 2
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL"
+        ],
+        "seats": [
+            "9",
+            "10"
+        ],
+        "tickets": [
+            [
+                "available",
+                "9"
+            ],
+            [
+                "available",
+                "10"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 216.3,
+        "format": "Physical",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 210,
+        "ticket_costs": [
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "RHk4c3hWRzkzcUlteXZMZVZiZ1d4KytrK2F0R2NEL2Znd0h4cXMxNllKND0tLW1sRHlWQzM2d0wwYVBOSHVNNnZwYkE9PQ==--feeb72903a2341dc8db98bad29e4114ca86e0dc4",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "middle level corner 221"
+    },
+    {
+        "id": 548276486,
+        "url": "/ticket_groups/548276486",
+        "type": "event",
+        "row": "18",
+        "section": "221",
+        "quantity": 2,
+        "available_quantity": 2,
+        "wholesale_price": 216.3,
+        "eticket": false,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": "Side Stage",
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2019-01-02T19:52:04Z",
+        "updated_at": "2019-01-02T19:52:05Z",
+        "splits": [
+            2
+        ],
+        "ticket_states": {
+            "available": 2
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL"
+        ],
+        "seats": [
+            "19",
+            "18"
+        ],
+        "tickets": [
+            [
+                "available",
+                "19"
+            ],
+            [
+                "available",
+                "18"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 216.3,
+        "format": "Physical",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 210,
+        "ticket_costs": [
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "MXJPZGVaK2VQZVJJU1grQkJSM2lzOUhhQkY3NVdCMVdXUUdGdW1IRlZFVT0tLUFLNHNSQXg5V0szQzdEdE1FckkvVWc9PQ==--58adfde0daab50cf32b93a4a39224a66ff0ebf4e",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "middle level corner 221"
+    },
+    {
+        "id": 548276510,
+        "url": "/ticket_groups/548276510",
+        "type": "event",
+        "row": "8",
+        "section": "221",
+        "quantity": 8,
+        "available_quantity": 8,
+        "wholesale_price": 218.36,
+        "eticket": false,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": "Side Stage",
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2019-01-02T19:52:06Z",
+        "updated_at": "2019-01-02T19:52:06Z",
+        "splits": [
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            8
+        ],
+        "ticket_states": {
+            "available": 8
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [
+            "12",
+            "18",
+            "17",
+            "16",
+            "15",
+            "14",
+            "13",
+            "11"
+        ],
+        "tickets": [
+            [
+                "available",
+                "12"
+            ],
+            [
+                "available",
+                "18"
+            ],
+            [
+                "available",
+                "17"
+            ],
+            [
+                "available",
+                "16"
+            ],
+            [
+                "available",
+                "15"
+            ],
+            [
+                "available",
+                "14"
+            ],
+            [
+                "available",
+                "13"
+            ],
+            [
+                "available",
+                "11"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 218.36,
+        "format": "Physical",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 212,
+        "ticket_costs": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "MU5HWjVmdmpMTUpZY2pLanhyRDVWeStCaWh5K0tsTmVQbGxpNFZiNVJXST0tLTJNTFRpWERNQ2lQeU9QOXMwMUkyRGc9PQ==--06e36bdd30c46ec32ff15f5bf64fce53854a3cc2",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "middle level corner 221"
+    },
+    {
+        "id": 539850847,
+        "url": "/ticket_groups/539850847",
+        "type": "event",
+        "row": "1",
+        "section": "312",
+        "quantity": 2,
+        "available_quantity": 2,
+        "wholesale_price": 220.42,
+        "eticket": true,
+        "instant_delivery": true,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": null,
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-12-10T21:28:42Z",
+        "updated_at": "2018-12-10T21:28:42Z",
+        "splits": [
+            2
+        ],
+        "ticket_states": {
+            "available": 2
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL"
+        ],
+        "seats": [],
+        "tickets": [
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 220.42,
+        "format": "Eticket",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 214,
+        "ticket_costs": [
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "VHArY0ZCOEp0NFZua1R4NnF2RjFzOTZKd2VDU3VISy9tdkZLcE85bURJTT0tLVNVOEpINnc5T3AxNDRPc0hVb3Q4YWc9PQ==--bec114a087f5f33c334f62ff27227c6319b1685f",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "chase bridges 312"
+    },
+    {
+        "id": 548276474,
+        "url": "/ticket_groups/548276474",
+        "type": "event",
+        "row": "4",
+        "section": "221",
+        "quantity": 4,
+        "available_quantity": 4,
+        "wholesale_price": 222.48,
+        "eticket": false,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": "Side Stage",
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2019-01-02T19:52:04Z",
+        "updated_at": "2019-01-02T19:52:04Z",
+        "splits": [
+            2,
+            4
+        ],
+        "ticket_states": {
+            "available": 4
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [
+            "14",
+            "15",
+            "16",
+            "17"
+        ],
+        "tickets": [
+            [
+                "available",
+                "14"
+            ],
+            [
+                "available",
+                "15"
+            ],
+            [
+                "available",
+                "16"
+            ],
+            [
+                "available",
+                "17"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 222.48,
+        "format": "Physical",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 216,
+        "ticket_costs": [
+            null,
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "ZHlqNGI5Z3JIeFA5VEY0R2FvNG1McnBDdnRPV3dWd1puajFoTkJxWmxNbz0tLWczdlRIdFJ2WVQrK2t3Qi8vWlZtL0E9PQ==--cac785c82516e44901c33ead9785df196571788e",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "middle level corner 221"
+    },
+    {
+        "id": 548276484,
+        "url": "/ticket_groups/548276484",
+        "type": "event",
+        "row": "3",
+        "section": "221",
+        "quantity": 2,
+        "available_quantity": 2,
+        "wholesale_price": 223.51,
+        "eticket": false,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": "Side Stage",
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2019-01-02T19:52:04Z",
+        "updated_at": "2019-01-02T19:52:05Z",
+        "splits": [
+            2
+        ],
+        "ticket_states": {
+            "available": 2
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL"
+        ],
+        "seats": [
+            "14",
+            "13"
+        ],
+        "tickets": [
+            [
+                "available",
+                "14"
+            ],
+            [
+                "available",
+                "13"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 223.51,
+        "format": "Physical",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 217,
+        "ticket_costs": [
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "WkcrS0lWTTFpalYxVFlqUzNHKzRiWFZQbUVZcHRieUtCNlZtS1BXMlFnRT0tLWtSOXZPRGVGZ3RaSWZOenBkNE5zSUE9PQ==--b18b827f02647e7840557b392319e5646f7767e4",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "middle level corner 221"
+    },
+    {
+        "id": 538626289,
+        "url": "/ticket_groups/538626289",
+        "type": "event",
+        "row": "1",
+        "section": "315",
+        "quantity": 4,
+        "available_quantity": 4,
+        "wholesale_price": 237.93,
+        "eticket": true,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": "SIDE STAGE",
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-12-06T23:45:27Z",
+        "updated_at": "2018-12-06T23:45:27Z",
+        "splits": [
+            2,
+            4
+        ],
+        "ticket_states": {
+            "available": 4
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [],
+        "tickets": [
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 237.93,
+        "format": "Eticket",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 231,
+        "ticket_costs": [
+            null,
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "aTZEL0NjY1oxN1VNb2dSSkJHeEJwellOUDlDVTNpSUdsKzBSWDRLeUtCWT0tLUFtQlFXaXU1d0FXTy9tTUp1MUh0OGc9PQ==--9e73fb34d062dc7bb3940a68654c97e5480a69bf",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": true,
+        "tevo_section_name": "chase bridges 315"
+    },
+    {
+        "id": 526790175,
+        "url": "/ticket_groups/526790175",
+        "type": "event",
+        "row": "B25",
+        "section": "225",
+        "quantity": 3,
+        "available_quantity": 3,
+        "wholesale_price": 244.11,
+        "eticket": true,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": null,
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-11-04T23:40:53Z",
+        "updated_at": "2018-12-10T15:17:53Z",
+        "splits": [
+            1,
+            3
+        ],
+        "ticket_states": {
+            "available": 3
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [],
+        "tickets": [
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 244.11,
+        "format": "Eticket",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 237,
+        "ticket_costs": [
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "UlZlQVVUajJhMFQ5TFVRTFE3NFdLS2swQUlOSGxLWWpNNDl5NG1hVjlLND0tLWp1YXlzZVhMWWYzd3hqaFFoMjNRVXc9PQ==--8ed88742f8ed89e5f4fe7bcb25bbb009c01021cb",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": true,
+        "tevo_section_name": "middle level sideline 225"
+    },
+    {
+        "id": 528455638,
+        "url": "/ticket_groups/528455638",
+        "type": "event",
+        "row": "15",
+        "section": "221",
+        "quantity": 4,
+        "available_quantity": 4,
+        "wholesale_price": 249.26,
+        "eticket": false,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": "Side View",
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-11-09T20:11:19Z",
+        "updated_at": "2018-12-11T15:43:18Z",
+        "splits": [
+            2,
+            4
+        ],
+        "ticket_states": {
+            "available": 4
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [],
+        "tickets": [
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 249.26,
+        "format": "Physical",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 242,
+        "ticket_costs": [
+            null,
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "NkFaTlo0RXhyaHFVYkpyc2ZLdmorZzJDaVlVUVlSUm5ESFlDbDR1NmJ1RT0tLXF4TzVvZWVaUmhTcHVyY0RwTnI0RHc9PQ==--29641a0cb94ac7f182e17b9bfd6d0bedd33505fa",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": true,
+        "tevo_section_name": "middle level corner 221"
+    },
+    {
+        "id": 526790161,
+        "url": "/ticket_groups/526790161",
+        "type": "event",
+        "row": "B25",
+        "section": "210",
+        "quantity": 3,
+        "available_quantity": 3,
+        "wholesale_price": 254.41,
+        "eticket": true,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": null,
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-11-04T23:40:52Z",
+        "updated_at": "2018-12-10T15:17:52Z",
+        "splits": [
+            1,
+            3
+        ],
+        "ticket_states": {
+            "available": 3
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [],
+        "tickets": [
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 254.41,
+        "format": "Eticket",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 247,
+        "ticket_costs": [
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "aWt3dDlJdHdSM3k1M0V4bGJndGlYYldvK3BnZkhNK0oyY2tEOWZYV1hXbz0tLStxVjZkZElNNDNLd2F4Z001QTNzY3c9PQ==--594a461c5128f6b675e1175aff04a65779b0e34e",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": true,
+        "tevo_section_name": "210"
+    },
+    {
+        "id": 528455639,
+        "url": "/ticket_groups/528455639",
+        "type": "event",
+        "row": "13",
+        "section": "221",
+        "quantity": 2,
+        "available_quantity": 2,
+        "wholesale_price": 254.93,
+        "eticket": false,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": "Side View",
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-11-09T20:11:19Z",
+        "updated_at": "2018-12-11T15:43:17Z",
+        "splits": [
+            2
+        ],
+        "ticket_states": {
+            "available": 2
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL"
+        ],
+        "seats": [],
+        "tickets": [
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 254.93,
+        "format": "Physical",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 247.5,
+        "ticket_costs": [
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "elNuSEZjc0tRUjRPa2lyUHJkaE1CWmZQZUxYT0VoUENkbUhUNGIxdFQvaz0tLUFyYm41cmJxay9SeVJkUG5mbFR5MXc9PQ==--d925e54070c5743212c6bc46e5eb6d3607433dab",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": true,
+        "tevo_section_name": "middle level corner 221"
+    },
+    {
+        "id": 545584511,
+        "url": "/ticket_groups/545584511",
+        "type": "event",
+        "row": "20",
+        "section": "17",
+        "quantity": 3,
+        "available_quantity": 3,
+        "wholesale_price": 270.89,
+        "eticket": false,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": false,
+        "in_hand_on": "2019-06-11",
+        "remote_id": null,
+        "public_notes": null,
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-12-26T21:08:43Z",
+        "updated_at": "2018-12-26T21:08:43Z",
+        "splits": [
+            1,
+            3
+        ],
+        "ticket_states": {
+            "available": 3
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [
+            "19",
+            "17",
+            "18"
+        ],
+        "tickets": [
+            [
+                "available",
+                "19"
+            ],
+            [
+                "available",
+                "17"
+            ],
+            [
+                "available",
+                "18"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 270.89,
+        "format": "Physical",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 263,
+        "ticket_costs": [
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "MTlBSWtMaEZWMWJ6dGdGSGhSWURFYStvUC8vS3hXZTJNdmlqd0dJdDZabz0tLUdYRG9rbG56ajk2QTUxKzF0SXNtMFE9PQ==--0608ad75f05daa8a641acb095a7ace00f0e1256a",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "17"
+    },
+    {
+        "id": 545584507,
+        "url": "/ticket_groups/545584507",
+        "type": "event",
+        "row": "20",
+        "section": "15",
+        "quantity": 3,
+        "available_quantity": 3,
+        "wholesale_price": 270.89,
+        "eticket": false,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": false,
+        "in_hand_on": "2019-06-11",
+        "remote_id": null,
+        "public_notes": null,
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-12-26T21:08:41Z",
+        "updated_at": "2018-12-26T21:08:42Z",
+        "splits": [
+            1,
+            3
+        ],
+        "ticket_states": {
+            "available": 3
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [
+            "2",
+            "3",
+            "1"
+        ],
+        "tickets": [
+            [
+                "available",
+                "2"
+            ],
+            [
+                "available",
+                "3"
+            ],
+            [
+                "available",
+                "1"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 270.89,
+        "format": "Physical",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 263,
+        "ticket_costs": [
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "dkVxdFBOdTF4andaajYxMXZMVVhxVE1WRHBYblJCa0RVK254ams0U2MzRT0tLVpqWUZzay9DRHluQ0EyNUI2ODFRdnc9PQ==--20378eac06feee127b60df33af6ea2db692dd46a",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "15"
+    },
+    {
+        "id": 545584513,
+        "url": "/ticket_groups/545584513",
+        "type": "event",
+        "row": "18",
+        "section": "19",
+        "quantity": 2,
+        "available_quantity": 2,
+        "wholesale_price": 272.95,
+        "eticket": false,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": false,
+        "in_hand_on": "2019-06-11",
+        "remote_id": null,
+        "public_notes": null,
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-12-26T21:08:43Z",
+        "updated_at": "2018-12-26T21:08:44Z",
+        "splits": [
+            2
+        ],
+        "ticket_states": {
+            "available": 2
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL"
+        ],
+        "seats": [
+            "6",
+            "5"
+        ],
+        "tickets": [
+            [
+                "available",
+                "6"
+            ],
+            [
+                "available",
+                "5"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 272.95,
+        "format": "Physical",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 265,
+        "ticket_costs": [
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "aGFiN09lZnZOdzBwNDZhNzh4enhlVmN1STc4RGxtcTVIRzgrUkgyUDlRVT0tLWJjbC9vNjNZVVdkV3VBYXBjcno5MkE9PQ==--3d3c1958f36b4df13d193d66d61b167d10b59b60",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "19"
+    },
+    {
+        "id": 541694922,
+        "url": "/ticket_groups/541694922",
+        "type": "event",
+        "row": "12",
+        "section": "226",
+        "quantity": 5,
+        "available_quantity": 5,
+        "wholesale_price": 273.65,
+        "eticket": true,
+        "instant_delivery": true,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": "eTicket",
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-12-15T23:31:41Z",
+        "updated_at": "2019-01-02T00:00:55Z",
+        "splits": [
+            1,
+            2,
+            3,
+            5
+        ],
+        "ticket_states": {
+            "available": 5
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [],
+        "tickets": [
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 273.65,
+        "format": "Eticket",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 265.68,
+        "ticket_costs": [
+            null,
+            null,
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "YWVuSnlWL0JaSmdSMGltL2E5OFV2NHZwSm1iWkE1c0hELy9DVTN5OWtYdz0tLTIxV3EzM2RwQ0liMDNyUDJMK2k4aXc9PQ==--8849cb5df9e53edb98310fdf908e59d00d5f18d2",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "middle level corner 226"
+    },
+    {
+        "id": 540629618,
+        "url": "/ticket_groups/540629618",
+        "type": "event",
+        "row": "2",
+        "section": "314",
+        "quantity": 7,
+        "available_quantity": 7,
+        "wholesale_price": 274.72,
+        "eticket": true,
+        "instant_delivery": true,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": null,
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-12-13T01:03:42Z",
+        "updated_at": "2018-12-20T22:57:57Z",
+        "splits": [
+            1,
+            2,
+            3,
+            4,
+            5,
+            7
+        ],
+        "ticket_states": {
+            "available": 7
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [],
+        "tickets": [
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 274.72,
+        "format": "Eticket",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 266.72,
+        "ticket_costs": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "WEtLOXM3b05VRjF3ZXFjalIvL1k0WTFGbnF4TnpaTHJtUnZiYnVxc21jZz0tLW9tbnRyT3g0YVI0cXZhNFo4VnNNUnc9PQ==--00f59c15ea6b597d9a20eb5e31d54f3c2fc5bafa",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": true,
+        "tevo_section_name": "314"
+    },
+    {
+        "id": 541475409,
+        "url": "/ticket_groups/541475409",
+        "type": "event",
+        "row": "24",
+        "section": "226",
+        "quantity": 4,
+        "available_quantity": 4,
+        "wholesale_price": 276.04,
+        "eticket": true,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": null,
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-12-15T07:45:45Z",
+        "updated_at": "2018-12-15T07:45:45Z",
+        "splits": [
+            2,
+            4
+        ],
+        "ticket_states": {
+            "available": 4
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [],
+        "tickets": [
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 276.04,
+        "format": "Eticket",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 268,
+        "ticket_costs": [
+            null,
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "Rkd2cmlCdXllSllodDZQNWVrVlVsSVhQbG1UVTdwMGkvMklrMWhnZ05lTT0tLTEzSEdpbnFncVRnaUR1Wi82RS9ISmc9PQ==--c9ace8b08d0d91807b02e22cbee2d1675d569013",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": true,
+        "tevo_section_name": "middle level corner 226"
+    },
+    {
+        "id": 544278707,
+        "url": "/ticket_groups/544278707",
+        "type": "event",
+        "row": "23",
+        "section": "212",
+        "quantity": 4,
+        "available_quantity": 4,
+        "wholesale_price": 278.1,
+        "eticket": true,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": null,
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-12-21T20:07:02Z",
+        "updated_at": "2018-12-24T21:08:40Z",
+        "splits": [
+            2,
+            4
+        ],
+        "ticket_states": {
+            "available": 4
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [
+            "17",
+            "20",
+            "19",
+            "18"
+        ],
+        "tickets": [
+            [
+                "available",
+                "17"
+            ],
+            [
+                "available",
+                "20"
+            ],
+            [
+                "available",
+                "19"
+            ],
+            [
+                "available",
+                "18"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 278.1,
+        "format": "Eticket",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 270,
+        "ticket_costs": [
+            null,
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "SG9qa2Z1TnFHSUE1STlFVGVibFpnbU1ndkFka1dGWjR1cFBqZHoyK3VFVT0tLXQ1UzhlSGtDaXNVMFIra3ZuMk1VcHc9PQ==--b6659828a3640f49710078cde40701b508431499",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "middle level sideline 212"
+    },
+    {
+        "id": 539793641,
+        "url": "/ticket_groups/539793641",
+        "type": "event",
+        "row": "1",
+        "section": "326",
+        "quantity": 4,
+        "available_quantity": 4,
+        "wholesale_price": 280.86,
+        "eticket": true,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": null,
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-12-10T18:50:41Z",
+        "updated_at": "2018-12-16T19:28:14Z",
+        "splits": [
+            2,
+            4
+        ],
+        "ticket_states": {
+            "available": 4
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [],
+        "tickets": [
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 280.86,
+        "format": "Eticket",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 272.68,
+        "ticket_costs": [
+            null,
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "MGUvenN6UEdWcDlWL1Bnc0xxb3BIMGh6MlI1cDEyeG5VaHNGdE9sNGFSST0tLVR0NktzSFIyUjFBZ1ZvZ1NMbUlvWlE9PQ==--f2cdfd072025fcf63cc49e90636acc10fc154ace",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": true,
+        "tevo_section_name": "326"
+    },
+    {
+        "id": 540629623,
+        "url": "/ticket_groups/540629623",
+        "type": "event",
+        "row": "24",
+        "section": "212",
+        "quantity": 2,
+        "available_quantity": 2,
+        "wholesale_price": 280.86,
+        "eticket": true,
+        "instant_delivery": true,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": null,
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-12-13T01:03:48Z",
+        "updated_at": "2018-12-20T22:58:13Z",
+        "splits": [
+            2
+        ],
+        "ticket_states": {
+            "available": 2
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL"
+        ],
+        "seats": [],
+        "tickets": [
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 280.86,
+        "format": "Eticket",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 272.68,
+        "ticket_costs": [
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "dCtzMHBaNVIwK2ZXWUZ1blJ0eWdoWHRMU3dKY1F0aG1lRVpjRzhBZ2pvRT0tLW1KNmJQTkJPT0hwSVRONFBhdm5wQ3c9PQ==--a575603e2e1d0a42d2535fd5fae0d92928a47f28",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": true,
+        "tevo_section_name": "middle level sideline 212"
+    },
+    {
+        "id": 537919926,
+        "url": "/ticket_groups/537919926",
+        "type": "event",
+        "row": "5",
+        "section": "211",
+        "quantity": 3,
+        "available_quantity": 3,
+        "wholesale_price": 282.23,
+        "eticket": true,
+        "instant_delivery": true,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": null,
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-12-05T01:59:16Z",
+        "updated_at": "2018-12-16T16:31:41Z",
+        "splits": [
+            1,
+            3
+        ],
+        "ticket_states": {
+            "available": 3
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [
+            "10",
+            "8",
+            "9"
+        ],
+        "tickets": [
+            [
+                "available",
+                "10"
+            ],
+            [
+                "available",
+                "8"
+            ],
+            [
+                "available",
+                "9"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 282.23,
+        "format": "Eticket",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 274.01,
+        "ticket_costs": [
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "UHRlME9ldllTRFBYVGVHOGJiTjNnYUkzRXdXQ0c2dVdKK3dNYmMzQWk3TT0tLXhyRi9HVGUrRnJMNW90NkxhRE53a2c9PQ==--e3c4deb963fe7141cf125feede8c14b1c1c99057",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": true,
+        "tevo_section_name": "middle level sideline 211"
+    },
+    {
+        "id": 542257909,
+        "url": "/ticket_groups/542257909",
+        "type": "event",
+        "row": "23",
+        "section": "212",
+        "quantity": 2,
+        "available_quantity": 2,
+        "wholesale_price": 283.25,
+        "eticket": true,
+        "instant_delivery": true,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": null,
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-12-17T19:33:05Z",
+        "updated_at": "2018-12-17T23:40:15Z",
+        "splits": [
+            2
+        ],
+        "ticket_states": {
+            "available": 2
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL"
+        ],
+        "seats": [],
+        "tickets": [
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 283.25,
+        "format": "Eticket",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 275,
+        "ticket_costs": [
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "K2pMT3llMkcyOC93WDRhbG5hWmdqM0FDOGhETWxBcTREaTl2cFFQVU5kTT0tLUpPL0hHZmtXOUVMUTV1MkNqOTlpWkE9PQ==--2ad096bebd9a25a7dc3d2d6931aaca5b98136478",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "middle level sideline 212"
+    },
+    {
+        "id": 548123488,
+        "url": "/ticket_groups/548123488",
+        "type": "event",
+        "row": "3",
+        "section": "211",
+        "quantity": 6,
+        "available_quantity": 6,
+        "wholesale_price": 289.43,
+        "eticket": true,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": null,
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2019-01-02T04:47:47Z",
+        "updated_at": "2019-01-02T04:47:47Z",
+        "splits": [
+            1,
+            2,
+            3,
+            4,
+            6
+        ],
+        "ticket_states": {
+            "available": 6
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [],
+        "tickets": [
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 289.43,
+        "format": "Eticket",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 281,
+        "ticket_costs": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "aHFmWmQ5aEF3aWdTMmJyUmg5eG1xVWNjVnVtd0xPK0RUR3ZQZWkyZkQxdz0tLSt3dS8wVk1hVWpxZGRzdHg5OXN1T2c9PQ==--831bc79aa4f5e7761656e98a5bb7b32670e98383",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": true,
+        "tevo_section_name": "middle level sideline 211"
+    },
+    {
+        "id": 548276479,
+        "url": "/ticket_groups/548276479",
+        "type": "event",
+        "row": "7",
+        "section": "201",
+        "quantity": 2,
+        "available_quantity": 2,
+        "wholesale_price": 300.76,
+        "eticket": false,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": null,
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2019-01-02T19:52:04Z",
+        "updated_at": "2019-01-02T19:52:04Z",
+        "splits": [
+            2
+        ],
+        "ticket_states": {
+            "available": 2
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL"
+        ],
+        "seats": [
+            "4",
+            "3"
+        ],
+        "tickets": [
+            [
+                "available",
+                "4"
+            ],
+            [
+                "available",
+                "3"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 300.76,
+        "format": "Physical",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 292,
+        "ticket_costs": [
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "RTVnTUE2Z2p1b01wMmJsZjVFRHMxSXp6QmNsVHc0bjA4VFpCNGE2dm1oOD0tLVdNc3hFcXFLRndBeFBtb0p2MzFraUE9PQ==--f7cb0851d34e14ad50e6a11a12c114ebcf68aab6",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "middle level corner 201"
+    },
+    {
+        "id": 548276475,
+        "url": "/ticket_groups/548276475",
+        "type": "event",
+        "row": "6",
+        "section": "201",
+        "quantity": 2,
+        "available_quantity": 2,
+        "wholesale_price": 301.79,
+        "eticket": false,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": null,
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2019-01-02T19:52:04Z",
+        "updated_at": "2019-01-02T19:52:04Z",
+        "splits": [
+            2
+        ],
+        "ticket_states": {
+            "available": 2
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL"
+        ],
+        "seats": [
+            "16",
+            "17"
+        ],
+        "tickets": [
+            [
+                "available",
+                "16"
+            ],
+            [
+                "available",
+                "17"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 301.79,
+        "format": "Physical",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 293,
+        "ticket_costs": [
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "OUlHVmw1MUpVMHNxNjRDbUZ2QTdNcEh6WC9DR24yMHR3SDJjYVF4clZtZz0tLTZzQnZ2cEVCeUduV01FdEVyNmIwRVE9PQ==--dc1617849557a2e9480ea6a4ec2f3da173982973",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "middle level corner 201"
+    },
+    {
+        "id": 542257857,
+        "url": "/ticket_groups/542257857",
+        "type": "event",
+        "row": "5",
+        "section": "211",
+        "quantity": 2,
+        "available_quantity": 2,
+        "wholesale_price": 301.84,
+        "eticket": true,
+        "instant_delivery": true,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": null,
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-12-17T19:33:02Z",
+        "updated_at": "2018-12-17T23:40:15Z",
+        "splits": [
+            2
+        ],
+        "ticket_states": {
+            "available": 2
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL"
+        ],
+        "seats": [],
+        "tickets": [
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 301.84,
+        "format": "Eticket",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 293.05,
+        "ticket_costs": [
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "SUZkRy9jeTN6TVZTeVVnNFhDTFVCbVpFSU1TOHBGbk1KY1RkTnVtU0w1VT0tLW9uMzNlc29adzA2cy9NUTJSSEllV0E9PQ==--43bcb7ebea7c944f6c846b2da10e7d7f97c7fce0",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "middle level sideline 211"
+    },
+    {
+        "id": 548276469,
+        "url": "/ticket_groups/548276469",
+        "type": "event",
+        "row": "5",
+        "section": "202",
+        "quantity": 4,
+        "available_quantity": 4,
+        "wholesale_price": 302.82,
+        "eticket": false,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": null,
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2019-01-02T19:52:03Z",
+        "updated_at": "2019-01-02T19:52:03Z",
+        "splits": [
+            2,
+            4
+        ],
+        "ticket_states": {
+            "available": 4
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [
+            "3",
+            "6",
+            "5",
+            "4"
+        ],
+        "tickets": [
+            [
+                "available",
+                "3"
+            ],
+            [
+                "available",
+                "6"
+            ],
+            [
+                "available",
+                "5"
+            ],
+            [
+                "available",
+                "4"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 302.82,
+        "format": "Physical",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 294,
+        "ticket_costs": [
+            null,
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "VGdLSmxqSTZCZnlUMFhwa0VNaHlpR3JpYXozeDhtWnNYU2s3T2pmZEFZVT0tLXBMdHhyeXlvcFMvZUZNVGhkc21wZVE9PQ==--6dcb4b44c95e06bb55871a598019bb186859091a",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "202"
+    },
+    {
+        "id": 548276473,
+        "url": "/ticket_groups/548276473",
+        "type": "event",
+        "row": "5",
+        "section": "207",
+        "quantity": 2,
+        "available_quantity": 2,
+        "wholesale_price": 302.82,
+        "eticket": false,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": null,
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2019-01-02T19:52:04Z",
+        "updated_at": "2019-01-02T19:52:04Z",
+        "splits": [
+            2
+        ],
+        "ticket_states": {
+            "available": 2
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL"
+        ],
+        "seats": [
+            "14",
+            "15"
+        ],
+        "tickets": [
+            [
+                "available",
+                "14"
+            ],
+            [
+                "available",
+                "15"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 302.82,
+        "format": "Physical",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 294,
+        "ticket_costs": [
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "R2hIWWw1SzF2V3JhSmo0VDZEYU4xb3M1MDAxK3k4NTNXSTdyTHIycVFOVT0tLTc5MEtDRmlpWFZ5bGlGYUJHWGlkRHc9PQ==--3f10dadd8394b48d2e1d3b91157a5f315df12027",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "207"
+    },
+    {
+        "id": 548276482,
+        "url": "/ticket_groups/548276482",
+        "type": "event",
+        "row": "6",
+        "section": "202",
+        "quantity": 3,
+        "available_quantity": 3,
+        "wholesale_price": 303.85,
+        "eticket": false,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": null,
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2019-01-02T19:52:04Z",
+        "updated_at": "2019-01-02T19:52:04Z",
+        "splits": [
+            1,
+            3
+        ],
+        "ticket_states": {
+            "available": 3
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [
+            "3",
+            "5",
+            "4"
+        ],
+        "tickets": [
+            [
+                "available",
+                "3"
+            ],
+            [
+                "available",
+                "5"
+            ],
+            [
+                "available",
+                "4"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 303.85,
+        "format": "Physical",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 295,
+        "ticket_costs": [
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "b2VnTVB2d25sTGJnOXlNamtaU2V3NnovSU91QmFmTXBSS0tCTlJHd3AxWT0tLWJzSHpMb0JEeGtqd21pc0lNdnVHWWc9PQ==--566192df1ab7d7af81cb25418ccc6cd883720e42",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "202"
+    },
+    {
+        "id": 535036288,
+        "url": "/ticket_groups/535036288",
+        "type": "event",
+        "row": "11",
+        "section": "221",
+        "quantity": 2,
+        "available_quantity": 2,
+        "wholesale_price": 308.18,
+        "eticket": true,
+        "instant_delivery": true,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": "Side View",
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-11-26T15:48:29Z",
+        "updated_at": "2018-12-24T18:17:15Z",
+        "splits": [
+            2
+        ],
+        "ticket_states": {
+            "available": 2
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL"
+        ],
+        "seats": [
+            "20",
+            "19"
+        ],
+        "tickets": [
+            [
+                "available",
+                "20"
+            ],
+            [
+                "available",
+                "19"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 308.18,
+        "format": "Eticket",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 314.95,
+        "ticket_costs": [
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "RVdHZXRDc2EyUGhZTjg5S1lFcHY5NGRDbkVJUEtFbHhheVdYYjJkdE5Odz0tLXN2UzRBYmdadG56R3RXZDErQU1KVXc9PQ==--e6da8ca8d378749ed0430febcb8d18769ec7c787",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "middle level corner 221"
+    },
+    {
+        "id": 524708265,
+        "url": "/ticket_groups/524708265",
+        "type": "event",
+        "row": "15",
+        "section": "211",
+        "quantity": 4,
+        "available_quantity": 4,
+        "wholesale_price": 341.5,
+        "eticket": true,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": false,
+        "in_hand_on": "2019-06-17",
+        "remote_id": null,
+        "public_notes": "mobileqr Mobile Entry. Do not print these tickets. Scan your tickets from your mobile phone for this event. Mobile ticket: Scan your tickets from your mobile phone for this event. Do not print these tickets..",
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-10-31T17:19:16Z",
+        "updated_at": "2018-12-18T15:27:08Z",
+        "splits": [
+            2,
+            4
+        ],
+        "ticket_states": {
+            "available": 4
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [],
+        "tickets": [
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 341.5,
+        "format": "Eticket",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 331.55,
+        "ticket_costs": [
+            null,
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "Ui9PSjF2VzJIQ1J1NURJaVo4bS8wVUJWMVNBcXBSdFBKeFgyMmJUN2lPVT0tLTFSRGlzRFZSeUc3YmdBQVJhcTdGbkE9PQ==--eea4023181c0ee1010b84451ed9838b29b33284b",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "middle level sideline 211"
+    },
+    {
+        "id": 548276524,
+        "url": "/ticket_groups/548276524",
+        "type": "event",
+        "row": "17",
+        "section": "115",
+        "quantity": 2,
+        "available_quantity": 2,
+        "wholesale_price": 349.17,
+        "eticket": false,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": "Side Stage",
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2019-01-02T19:52:07Z",
+        "updated_at": "2019-01-02T19:52:07Z",
+        "splits": [
+            2
+        ],
+        "ticket_states": {
+            "available": 2
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL"
+        ],
+        "seats": [
+            "5",
+            "6"
+        ],
+        "tickets": [
+            [
+                "available",
+                "5"
+            ],
+            [
+                "available",
+                "6"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 349.17,
+        "format": "Physical",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 339,
+        "ticket_costs": [
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "b1dPd3B0OXBWT3VmVmVJZ3Y0MGhoSnhGSUtHcVA4NGZFd2VmdnExZ0NHYz0tLUFRdElvL3ZMSWdvTDVIK0J5NWI5bWc9PQ==--2cedff03e4e61eeba93341a73200f0b241a1db92",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "lower level corner 115"
+    },
+    {
+        "id": 537368875,
+        "url": "/ticket_groups/537368875",
+        "type": "event",
+        "row": "14",
+        "section": "118",
+        "quantity": 3,
+        "available_quantity": 3,
+        "wholesale_price": 360.5,
+        "eticket": false,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": null,
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-12-03T17:00:33Z",
+        "updated_at": "2018-12-05T01:06:07Z",
+        "splits": [
+            1,
+            3
+        ],
+        "ticket_states": {
+            "available": 3
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [],
+        "tickets": [
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 360.5,
+        "format": "Physical",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 350,
+        "ticket_costs": [
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "L0NvTWlXRWJPNW8vWnpYZC92RjBwYTc5Ukw4b3JvL1d0Ym9wU0RJM0c3bz0tLTVPZWgvQVdCa0ljZnFDR1BGUkJpZGc9PQ==--a46f1174b1ab4a79c6ada8451fdddac6b9448da9",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "lower level sideline 118"
+    },
+    {
+        "id": 530809005,
+        "url": "/ticket_groups/530809005",
+        "type": "event",
+        "row": "17",
+        "section": "209",
+        "quantity": 4,
+        "available_quantity": 4,
+        "wholesale_price": 369.77,
+        "eticket": true,
+        "instant_delivery": true,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": null,
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-11-13T21:17:22Z",
+        "updated_at": "2018-12-21T19:58:20Z",
+        "splits": [
+            2,
+            4
+        ],
+        "ticket_states": {
+            "available": 4
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [
+            "14",
+            "16",
+            "13",
+            "15"
+        ],
+        "tickets": [
+            [
+                "available",
+                "14"
+            ],
+            [
+                "available",
+                "16"
+            ],
+            [
+                "available",
+                "13"
+            ],
+            [
+                "available",
+                "15"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 369.77,
+        "format": "Eticket",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 359,
+        "ticket_costs": [
+            null,
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "NWxrcUNvUUdsVmt3QmNsMzFpVFVTZlN5SGtzaEZDKzh3SCs0eXZ3ZnJRMD0tLW1vdFlBNjZBRGRRaUlvTUptNm5rSFE9PQ==--a832dde1ac479bd001d6bdf2b539cae6af982b64",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "middle level corner 209"
+    },
+    {
+        "id": 548276516,
+        "url": "/ticket_groups/548276516",
+        "type": "event",
+        "row": "9",
+        "section": "115",
+        "quantity": 2,
+        "available_quantity": 2,
+        "wholesale_price": 379.04,
+        "eticket": false,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": "Side Stage",
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2019-01-02T19:52:06Z",
+        "updated_at": "2019-01-02T19:52:07Z",
+        "splits": [
+            2
+        ],
+        "ticket_states": {
+            "available": 2
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL"
+        ],
+        "seats": [
+            "1",
+            "2"
+        ],
+        "tickets": [
+            [
+                "available",
+                "1"
+            ],
+            [
+                "available",
+                "2"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 379.04,
+        "format": "Physical",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 368,
+        "ticket_costs": [
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "Q3lGSXdEUWVzNC9xYnlQQnJnYlAxNW0rNXNqVVd6amVWVDZRdS9ERTgxbz0tLU9XU2xZMWs3VEF2WXhQeGVqaEhsdkE9PQ==--3d02d57c07ecdb3450817cb1ca4c1a2746cb7c74",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "lower level corner 115"
+    },
+    {
+        "id": 542638863,
+        "url": "/ticket_groups/542638863",
+        "type": "event",
+        "row": "4",
+        "section": "210",
+        "quantity": 4,
+        "available_quantity": 4,
+        "wholesale_price": 390.42,
+        "eticket": true,
+        "instant_delivery": true,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": null,
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-12-18T15:27:09Z",
+        "updated_at": "2018-12-18T15:28:43Z",
+        "splits": [
+            2,
+            4
+        ],
+        "ticket_states": {
+            "available": 4
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [
+            "8",
+            "11",
+            "10",
+            "9"
+        ],
+        "tickets": [
+            [
+                "available",
+                "8"
+            ],
+            [
+                "available",
+                "11"
+            ],
+            [
+                "available",
+                "10"
+            ],
+            [
+                "available",
+                "9"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 390.42,
+        "format": "Eticket",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 379.05,
+        "ticket_costs": [
+            null,
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "cDJ6T3JkUWtNN0lzc3hFL2lsNTFtTVNQL3lPOExmRkZTNzZzbVp0allrUT0tLUdpQ09mZlJPamhMM0M0TjRTY1g3Mnc9PQ==--046e541ac6194aa09d837fd1223a0561ba2b83f5",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "210"
+    },
+    {
+        "id": 548276508,
+        "url": "/ticket_groups/548276508",
+        "type": "event",
+        "row": "22",
+        "section": "115",
+        "quantity": 6,
+        "available_quantity": 6,
+        "wholesale_price": 396.55,
+        "eticket": false,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": "Side Stage",
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2019-01-02T19:52:05Z",
+        "updated_at": "2019-01-02T19:52:06Z",
+        "splits": [
+            1,
+            2,
+            3,
+            4,
+            6
+        ],
+        "ticket_states": {
+            "available": 6
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [
+            "2",
+            "6",
+            "5",
+            "4",
+            "3",
+            "1"
+        ],
+        "tickets": [
+            [
+                "available",
+                "2"
+            ],
+            [
+                "available",
+                "6"
+            ],
+            [
+                "available",
+                "5"
+            ],
+            [
+                "available",
+                "4"
+            ],
+            [
+                "available",
+                "3"
+            ],
+            [
+                "available",
+                "1"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 396.55,
+        "format": "Physical",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 385,
+        "ticket_costs": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "ejZtKzFacGdtUjVqNmkyeU1PYU14NzhPY3VGRWN1YVY2WER6ZzBIMTJrTT0tLXJ3SzR5dkVLM20yeUxOUXZyZmpSZHc9PQ==--2c8716fc1415dbff6f3e2c8c9920e2b5379f74fb",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "lower level corner 115"
+    },
+    {
+        "id": 540090149,
+        "url": "/ticket_groups/540090149",
+        "type": "event",
+        "row": "11",
+        "section": "FLOOR 2",
+        "quantity": 2,
+        "available_quantity": 2,
+        "wholesale_price": 401.7,
+        "eticket": true,
+        "instant_delivery": true,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": null,
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-12-11T16:41:45Z",
+        "updated_at": "2019-01-02T18:05:12Z",
+        "splits": [
+            2
+        ],
+        "ticket_states": {
+            "available": 2
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL"
+        ],
+        "seats": [],
+        "tickets": [
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 401.7,
+        "format": "Eticket",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 390,
+        "ticket_costs": [
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null
+        ],
+        "freshness": "< 120 mins",
+        "signature": "RUtXY2hlTkxzUHZoMmZ1SDdTZzJCVUNTOWl0SmpaZTI0cEMrUkhtODJPTT0tLU4yZjlCaGxhZXB6QWhEdDRQOVRaM0E9PQ==--192db4d3e83a2220c7ae3f4d6dbd07fdf43dc950",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "floor 2"
+    },
+    {
+        "id": 528174160,
+        "url": "/ticket_groups/528174160",
+        "type": "event",
+        "row": "16",
+        "section": "102",
+        "quantity": 5,
+        "available_quantity": 5,
+        "wholesale_price": 403.76,
+        "eticket": true,
+        "instant_delivery": true,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": null,
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-11-08T23:34:40Z",
+        "updated_at": "2018-12-22T16:46:19Z",
+        "splits": [
+            1,
+            2,
+            3,
+            5
+        ],
+        "ticket_states": {
+            "available": 5
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [],
+        "tickets": [
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 403.76,
+        "format": "Eticket",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 392,
+        "ticket_costs": [
+            null,
+            null,
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "RHlLYmJka0Rka2RrSU5PK3JFbVFoUG1tdXdIWU50djBFQWtOQVoxVUx6Zz0tLXNmb3RHU0Z2YXcwcFVIMi9yUFJPalE9PQ==--88f6ef8fb6d2a9f810c2146bfaf5ff2eed08bb53",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "lower level baseline 102"
+    },
+    {
+        "id": 535143988,
+        "url": "/ticket_groups/535143988",
+        "type": "event",
+        "row": "21",
+        "section": "104",
+        "quantity": 4,
+        "available_quantity": 4,
+        "wholesale_price": 410.92,
+        "eticket": true,
+        "instant_delivery": true,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": null,
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-11-26T20:28:20Z",
+        "updated_at": "2018-12-24T18:17:16Z",
+        "splits": [
+            2,
+            4
+        ],
+        "ticket_states": {
+            "available": 4
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [
+            "8",
+            "7",
+            "9",
+            "10"
+        ],
+        "tickets": [
+            [
+                "available",
+                "8"
+            ],
+            [
+                "available",
+                "7"
+            ],
+            [
+                "available",
+                "9"
+            ],
+            [
+                "available",
+                "10"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 410.92,
+        "format": "Eticket",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 419.95,
+        "ticket_costs": [
+            null,
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "VmdBL21YbUlMRCtNc1VzTmozM0Y2RnpGV0tVWHZOWFd2MFRKS1FwWlBnRT0tLVl2RElUdWJjS2tPVUUrenJnay9mK2c9PQ==--f92c61ac60e08c0c2367e510b0028c5008310136",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "lower level corner 104"
+    },
+    {
+        "id": 541557759,
+        "url": "/ticket_groups/541557759",
+        "type": "event",
+        "row": "13",
+        "section": "118",
+        "quantity": 2,
+        "available_quantity": 2,
+        "wholesale_price": 412,
+        "eticket": false,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": null,
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-12-15T16:23:56Z",
+        "updated_at": "2018-12-15T16:23:56Z",
+        "splits": [
+            2
+        ],
+        "ticket_states": {
+            "available": 2
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL"
+        ],
+        "seats": [],
+        "tickets": [
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 412,
+        "format": "Physical",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 400,
+        "ticket_costs": [
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "OWQ3dm9rZStVcTV0OHdkZzg3Y3RpandTeDExY2k0SzRVN1VUS2tDNUlvWT0tLWwwalY5RU42cDgwQjRXVHJQNU9GZVE9PQ==--da6fee4507626c557775720232a0f2cbe3f848dc",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "lower level sideline 118"
+    },
+    {
+        "id": 533614146,
+        "url": "/ticket_groups/533614146",
+        "type": "event",
+        "row": "18",
+        "section": "101",
+        "quantity": 4,
+        "available_quantity": 4,
+        "wholesale_price": 415.73,
+        "eticket": true,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": null,
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-11-21T19:37:33Z",
+        "updated_at": "2018-12-26T20:06:36Z",
+        "splits": [
+            2,
+            4
+        ],
+        "ticket_states": {
+            "available": 4
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [
+            "13",
+            "14",
+            "15",
+            "16"
+        ],
+        "tickets": [
+            [
+                "available",
+                "13"
+            ],
+            [
+                "available",
+                "14"
+            ],
+            [
+                "available",
+                "15"
+            ],
+            [
+                "available",
+                "16"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 415.73,
+        "format": "Eticket",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 413.97,
+        "ticket_costs": [
+            null,
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "NU1XWUtDSjQrVmVWdDFLbkVMZ3d5QW5qSlNwRXp4TEszQitJR2wvOERoUT0tLVVsSytJUGRJeWVnYjkwcmNYMU0xNlE9PQ==--8cc31e3c24e7133099180e96c24a053efb71c0ed",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "lower level baseline 101"
+    },
+    {
+        "id": 542668247,
+        "url": "/ticket_groups/542668247",
+        "type": "event",
+        "row": "1",
+        "section": "1",
+        "quantity": 2,
+        "available_quantity": 2,
+        "wholesale_price": 420.7,
+        "eticket": true,
+        "instant_delivery": true,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": null,
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-12-18T16:32:06Z",
+        "updated_at": "2019-01-02T18:26:08Z",
+        "splits": [
+            2
+        ],
+        "ticket_states": {
+            "available": 2
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL"
+        ],
+        "seats": [],
+        "tickets": [
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 420.7,
+        "format": "Eticket",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 408.45,
+        "ticket_costs": [
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "T0ZTaVdSM0gwZnRTWHJFUVNWVFNDdHJMZmpVYmd1emF1VGJtUm1pdEh4OD0tLXhvMDcyYU9YWEh4MHJjeEhBR08vS2c9PQ==--f1c5c8766084f2534442f26c7ab659c523bd74d0",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "floor 1"
+    },
+    {
+        "id": 525927819,
+        "url": "/ticket_groups/525927819",
+        "type": "event",
+        "row": "9",
+        "section": "2",
+        "quantity": 2,
+        "available_quantity": 2,
+        "wholesale_price": 424.58,
+        "eticket": true,
+        "instant_delivery": true,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": null,
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-11-02T15:57:40Z",
+        "updated_at": "2018-12-11T03:42:40Z",
+        "splits": [
+            2
+        ],
+        "ticket_states": {
+            "available": 2
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL"
+        ],
+        "seats": [],
+        "tickets": [
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 424.58,
+        "format": "Eticket",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 412.21,
+        "ticket_costs": [
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "US8wcHZCUnJKYzh1R2x4NHV5b0lNNFJvcFIxSkhnTGo1bHBpeWtVTFUwMD0tLVhXeFFreWNuZEpsT0ovYkpiRlk2bFE9PQ==--cc98d7f51a6d7a2e0be5dd912023e91607d5acb2",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": true,
+        "tevo_section_name": "2"
+    },
+    {
+        "id": 539754911,
+        "url": "/ticket_groups/539754911",
+        "type": "event",
+        "row": "2",
+        "section": "1",
+        "quantity": 2,
+        "available_quantity": 2,
+        "wholesale_price": 427.19,
+        "eticket": true,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": null,
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-12-10T16:43:36Z",
+        "updated_at": "2018-12-20T14:09:28Z",
+        "splits": [
+            2
+        ],
+        "ticket_states": {
+            "available": 2
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL"
+        ],
+        "seats": [],
+        "tickets": [
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 427.19,
+        "format": "Eticket",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 414.75,
+        "ticket_costs": [
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "ZjcrcVlwUXhSQWRMUU5ZcUxwbFZxNnhoYWhnMUdhZ2szYXNCOHMwVEpCWT0tLXExTXd3cmRQS05QRjRaS2RLd2xUS0E9PQ==--61461f068ee4b80083c56e388768fe6ce7681ee1",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "floor 1"
+    },
+    {
+        "id": 534088405,
+        "url": "/ticket_groups/534088405",
+        "type": "event",
+        "row": "14",
+        "section": "109",
+        "quantity": 7,
+        "available_quantity": 7,
+        "wholesale_price": 431.57,
+        "eticket": true,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": false,
+        "in_hand_on": "2019-06-16",
+        "remote_id": null,
+        "public_notes": "MOBILE ENTRY. Scan your tickets from your mobile phone for this event. Do not print these tickets - Ships by 06/16/2019.",
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-11-23T00:43:49Z",
+        "updated_at": "2018-11-30T21:30:49Z",
+        "splits": [
+            1,
+            2,
+            3,
+            4,
+            5,
+            7
+        ],
+        "ticket_states": {
+            "available": 7
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [],
+        "tickets": [
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 431.57,
+        "format": "Eticket",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 419,
+        "ticket_costs": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "Y09jcEpnMVBVaTBvS0tvbUlVZzFLenFuY0xLditObHhEQnN6emFBWUgrcz0tLXpObzByRW83UHhFZUMvMk9UKy9Za1E9PQ==--cef76fc99f4788b40e90075758d752576f30cc18",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": true,
+        "tevo_section_name": "lower level corner 109"
+    },
+    {
+        "id": 545227145,
+        "url": "/ticket_groups/545227145",
+        "type": "event",
+        "row": "19",
+        "section": "115",
+        "quantity": 4,
+        "available_quantity": 4,
+        "wholesale_price": 436.72,
+        "eticket": true,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": false,
+        "in_hand_on": "2019-06-17",
+        "remote_id": null,
+        "public_notes": null,
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-12-24T23:33:31Z",
+        "updated_at": "2019-01-01T20:41:08Z",
+        "splits": [
+            2,
+            4
+        ],
+        "ticket_states": {
+            "available": 4
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [],
+        "tickets": [
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 436.72,
+        "format": "Eticket",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 424,
+        "ticket_costs": [
+            null,
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "dllKMDNaSEg1cjNQMk1ueW9jeVZwUEhqSHFKdDBjbzdwUEw1RFQ3bFpTcz0tLXM5Y2theVhHYXk1V292ci9DZGNQRUE9PQ==--e537de0adcb6909d123b2855c431d312e5747ed6",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "lower level corner 115"
+    },
+    {
+        "id": 545171205,
+        "url": "/ticket_groups/545171205",
+        "type": "event",
+        "row": "19",
+        "section": "109",
+        "quantity": 4,
+        "available_quantity": 4,
+        "wholesale_price": 436.72,
+        "eticket": true,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": false,
+        "in_hand_on": "2019-06-17",
+        "remote_id": null,
+        "public_notes": null,
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-12-24T17:38:56Z",
+        "updated_at": "2019-01-01T20:41:08Z",
+        "splits": [
+            2,
+            4
+        ],
+        "ticket_states": {
+            "available": 4
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [],
+        "tickets": [
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 436.72,
+        "format": "Eticket",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 424,
+        "ticket_costs": [
+            null,
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "ZVlUYjFycEJYS3ZYMWQwRWxjUWN6WDFqYnVweWliMWhHUGIxZ2xUOVZzST0tLW9EbkxtcDhYL3NZOFg0dDJnRkZmTXc9PQ==--4b6162d4b2c161f24e6158311266521c823a62fd",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "lower level corner 109"
+    },
+    {
+        "id": 546329207,
+        "url": "/ticket_groups/546329207",
+        "type": "event",
+        "row": "21",
+        "section": "A",
+        "quantity": 3,
+        "available_quantity": 3,
+        "wholesale_price": 437.75,
+        "eticket": true,
+        "instant_delivery": true,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": null,
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-12-27T21:30:24Z",
+        "updated_at": "2018-12-27T21:30:24Z",
+        "splits": [
+            1,
+            3
+        ],
+        "ticket_states": {
+            "available": 3
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [],
+        "tickets": [
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 437.75,
+        "format": "Eticket",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 425,
+        "ticket_costs": [
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "bkRlS0lQL1ZOSXFXNzBreEdnSXk0b0ZvaFFlTnJPUEhOUjFveENVcWpCTT0tLVlBcGVRVjRxTTBOZFNqbGtHZlhmNUE9PQ==--6ff0fb4e0cbf5e79771556fc1ff0f32295bcf905",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "floor a"
+    },
+    {
+        "id": 544676048,
+        "url": "/ticket_groups/544676048",
+        "type": "event",
+        "row": "22",
+        "section": "106",
+        "quantity": 6,
+        "available_quantity": 6,
+        "wholesale_price": 441.87,
+        "eticket": true,
+        "instant_delivery": true,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": null,
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-12-23T02:38:24Z",
+        "updated_at": "2018-12-23T02:38:24Z",
+        "splits": [
+            1,
+            2,
+            3,
+            4,
+            6
+        ],
+        "ticket_states": {
+            "available": 6
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [],
+        "tickets": [
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 441.87,
+        "format": "Eticket",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 429,
+        "ticket_costs": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "RUFGWEFvVnNCbHZTRnpKNDVzZ0ZjSklaVXdJSjcxRzExYkpPVkJVUE1IOD0tLWtWQVdUUGs3R3EyOHZyUEFZbmJLSUE9PQ==--a7d0add824306c99cd5d0dbd48b4d0693f4835a1",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "lower level sideline 106"
+    },
+    {
+        "id": 541354792,
+        "url": "/ticket_groups/541354792",
+        "type": "event",
+        "row": "2",
+        "section": "1",
+        "quantity": 2,
+        "available_quantity": 2,
+        "wholesale_price": 444.96,
+        "eticket": true,
+        "instant_delivery": true,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": null,
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-12-14T22:53:06Z",
+        "updated_at": "2018-12-14T22:53:07Z",
+        "splits": [
+            2
+        ],
+        "ticket_states": {
+            "available": 2
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL"
+        ],
+        "seats": [],
+        "tickets": [
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 444.96,
+        "format": "Eticket",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 450,
+        "ticket_costs": [
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "TTJJTWxvUWIrOEs3RDFqcEJHSUJoWjJDUlhsTU9jTWdUZDBCRGVMT1htZz0tLUcrWFI2MVhhVDZyaTZLQUZ3WGp6S3c9PQ==--485268d938fd4bb3766c77cd4f7b2f7d7b2a71fe",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "floor 1"
+    },
+    {
+        "id": 541354787,
+        "url": "/ticket_groups/541354787",
+        "type": "event",
+        "row": "2",
+        "section": "3",
+        "quantity": 2,
+        "available_quantity": 2,
+        "wholesale_price": 444.96,
+        "eticket": true,
+        "instant_delivery": true,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": null,
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-12-14T22:53:05Z",
+        "updated_at": "2018-12-14T22:53:05Z",
+        "splits": [
+            2
+        ],
+        "ticket_states": {
+            "available": 2
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL"
+        ],
+        "seats": [],
+        "tickets": [
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 444.96,
+        "format": "Eticket",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 450,
+        "ticket_costs": [
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "c1QrNER3ZEZaTG00UTIweTFCK1dvYmhBWW11WE5FdmQ1Z1piRTdGeUQ4Yz0tLWRaN1psQ3JDckZKeTJxMkJQeDdHbmc9PQ==--8da1c5a1d986cd7f406024f9a9c5b28f6f7d410c",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "floor 3"
+    },
+    {
+        "id": 541354793,
+        "url": "/ticket_groups/541354793",
+        "type": "event",
+        "row": "2",
+        "section": "3",
+        "quantity": 2,
+        "available_quantity": 2,
+        "wholesale_price": 444.96,
+        "eticket": true,
+        "instant_delivery": true,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": null,
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-12-14T22:53:07Z",
+        "updated_at": "2018-12-14T22:53:07Z",
+        "splits": [
+            2
+        ],
+        "ticket_states": {
+            "available": 2
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL"
+        ],
+        "seats": [],
+        "tickets": [
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 444.96,
+        "format": "Eticket",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 450,
+        "ticket_costs": [
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "QzVnRUxRSFJoTG5nTE5QVlQwbkh2SzlYNWFCcXJtcDBYMUpOQkREVlFsTT0tLUlPM3NYUGRobXhEdFA4OEJZOGFLSlE9PQ==--719847cfcef24d0e07c859b7bfc67984b99d13be",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "floor 3"
+    },
+    {
+        "id": 533614157,
+        "url": "/ticket_groups/533614157",
+        "type": "event",
+        "row": "18",
+        "section": "104",
+        "quantity": 4,
+        "available_quantity": 4,
+        "wholesale_price": 448.99,
+        "eticket": true,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": null,
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-11-21T19:37:34Z",
+        "updated_at": "2018-12-26T20:06:37Z",
+        "splits": [
+            2,
+            4
+        ],
+        "ticket_states": {
+            "available": 4
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [
+            "6",
+            "5",
+            "4",
+            "3"
+        ],
+        "tickets": [
+            [
+                "available",
+                "6"
+            ],
+            [
+                "available",
+                "5"
+            ],
+            [
+                "available",
+                "4"
+            ],
+            [
+                "available",
+                "3"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 448.99,
+        "format": "Eticket",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 447.09,
+        "ticket_costs": [
+            null,
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "THlHMVBxUWxjYkhqYkRDVkVRTlovM2FmRmZ5VEtvbjc1ZC95azRrTEtZST0tLXJ0TVNsenYvOUtnckhoTWwvOEZmMUE9PQ==--aa350f2844f48b3dfb75ae179786d13806f18850",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "lower level corner 104"
+    },
+    {
+        "id": 544582536,
+        "url": "/ticket_groups/544582536",
+        "type": "event",
+        "row": "1",
+        "section": "1",
+        "quantity": 3,
+        "available_quantity": 3,
+        "wholesale_price": 458.35,
+        "eticket": true,
+        "instant_delivery": true,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": null,
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-12-22T16:48:37Z",
+        "updated_at": "2018-12-22T16:48:37Z",
+        "splits": [
+            1,
+            3
+        ],
+        "ticket_states": {
+            "available": 3
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [],
+        "tickets": [
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 458.35,
+        "format": "Eticket",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 445,
+        "ticket_costs": [
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "UnVUMVJSSlNkY0lPYklWdDNRYmlRMUhPeFEwVEFucGxHQlcwSy8yMHZOOD0tLXpZeWF4Ti9HdzlSR3dqMnFnNHRIYUE9PQ==--0fd4da7eb334382c3bf5a41a1f853fa7c522cfad",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "floor 1"
+    },
+    {
+        "id": 548156725,
+        "url": "/ticket_groups/548156725",
+        "type": "event",
+        "row": "20,21",
+        "section": "115",
+        "quantity": 8,
+        "available_quantity": 8,
+        "wholesale_price": 462.47,
+        "eticket": true,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": false,
+        "in_hand_on": "2019-06-15",
+        "remote_id": null,
+        "public_notes": "Piggy back seats. Aisle.",
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2019-01-02T12:59:46Z",
+        "updated_at": "2019-01-02T12:59:47Z",
+        "splits": [
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            8
+        ],
+        "ticket_states": {
+            "available": 8
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [],
+        "tickets": [
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 462.47,
+        "format": "Eticket",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 449,
+        "ticket_costs": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "ZTlCVlh4ajN0UitTaS9JT1JDQXBnejFZV1NvSzBudGFaT3B5TGtseUk4cz0tLWk5SkNLMHp3Y0o4U0xCRjBWcjhTM2c9PQ==--17bcad931310fe09e5824e9dcf74d04b3e88f4d5",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "lower level corner 115"
+    },
+    {
+        "id": 526917955,
+        "url": "/ticket_groups/526917955",
+        "type": "event",
+        "row": "16",
+        "section": "115",
+        "quantity": 4,
+        "available_quantity": 4,
+        "wholesale_price": 462.47,
+        "eticket": true,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": false,
+        "in_hand_on": "2019-06-16",
+        "remote_id": null,
+        "public_notes": "MOBILE ENTRY. Scan your tickets from your mobile phone for this event. Do not print these tickets - Ships by 06/16/2019.",
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-11-05T07:01:22Z",
+        "updated_at": "2018-11-30T21:30:49Z",
+        "splits": [
+            2,
+            4
+        ],
+        "ticket_states": {
+            "available": 4
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [],
+        "tickets": [
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 462.47,
+        "format": "Eticket",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 449,
+        "ticket_costs": [
+            null,
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "TnF2a3NibXlxUUh1M1VlUzArejgyalB1OGpEVDNTRmNFdFhTbkdxbW8yND0tLXNrcERzamlvajBsbVZpU3JFUmZJWlE9PQ==--7a472ffa56af550b2a3bca85e8578a6afc3c3206",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": true,
+        "tevo_section_name": "lower level corner 115"
+    },
+    {
+        "id": 544513407,
+        "url": "/ticket_groups/544513407",
+        "type": "event",
+        "row": "21",
+        "section": "B",
+        "quantity": 3,
+        "available_quantity": 3,
+        "wholesale_price": 468.51,
+        "eticket": true,
+        "instant_delivery": true,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": null,
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-12-22T14:11:56Z",
+        "updated_at": "2018-12-28T17:54:08Z",
+        "splits": [
+            1,
+            3
+        ],
+        "ticket_states": {
+            "available": 3
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [],
+        "tickets": [
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 468.51,
+        "format": "Eticket",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 454.86,
+        "ticket_costs": [
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 90 mins",
+        "signature": "RFgrTldJck5OZ01JcHdNODhXaUlIcm8xU25ZM1NBN0lqVlQzVlVuaTR1Yz0tLWtxRzhXNVFneDVqNmVWZXMvL1FhM1E9PQ==--fe19d97e6f1476486f2c332d857ab36d770a25a3",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "floor b"
+    },
+    {
+        "id": 540230882,
+        "url": "/ticket_groups/540230882",
+        "type": "event",
+        "row": "21",
+        "section": "A",
+        "quantity": 4,
+        "available_quantity": 4,
+        "wholesale_price": 472.77,
+        "eticket": true,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": false,
+        "in_hand_on": "2019-06-15",
+        "remote_id": null,
+        "public_notes": null,
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-12-11T22:52:25Z",
+        "updated_at": "2018-12-20T12:00:19Z",
+        "splits": [
+            2,
+            4
+        ],
+        "ticket_states": {
+            "available": 4
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [
+            "11",
+            "14",
+            "13",
+            "12"
+        ],
+        "tickets": [
+            [
+                "available",
+                "11"
+            ],
+            [
+                "available",
+                "14"
+            ],
+            [
+                "available",
+                "13"
+            ],
+            [
+                "available",
+                "12"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 472.77,
+        "format": "Eticket",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 459,
+        "ticket_costs": [
+            null,
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "TWZoYnRhNENBOFo0K1lCeXlLdkdsc05VNnBVWjFhSy9xME1USHZuWGI3ND0tLSsyS0dqak5QbU4yZnVYT2MyZUxTNlE9PQ==--128c0e4c1667729e81e3bcb4af8ebcdec8cb8898",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "floor a"
+    },
+    {
+        "id": 544903691,
+        "url": "/ticket_groups/544903691",
+        "type": "event",
+        "row": "21",
+        "section": "A",
+        "quantity": 11,
+        "available_quantity": 11,
+        "wholesale_price": 473.8,
+        "eticket": true,
+        "instant_delivery": true,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": null,
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-12-23T18:42:04Z",
+        "updated_at": "2018-12-23T18:42:04Z",
+        "splits": [
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            11
+        ],
+        "ticket_states": {
+            "available": 11
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [],
+        "tickets": [
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 473.8,
+        "format": "Eticket",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 460,
+        "ticket_costs": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "VzdYQ3A4a3NEWGpjbDkyMUZYcTIxdTI4UGVyUGpCSlliRjIyNXNIK2Q3bz0tLVBvTk8rbzZuUUlXRVVHTE9tUVFzNEE9PQ==--251fd1ee488c802008bae4acec615ef89b9ad249",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "floor a"
+    },
+    {
+        "id": 533618933,
+        "url": "/ticket_groups/533618933",
+        "type": "event",
+        "row": "20",
+        "section": "120",
+        "quantity": 12,
+        "available_quantity": 12,
+        "wholesale_price": 480.23,
+        "eticket": true,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": null,
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-11-21T19:43:13Z",
+        "updated_at": "2018-12-20T23:53:31Z",
+        "splits": [
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+            12
+        ],
+        "ticket_states": {
+            "available": 12
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [
+            "13",
+            "9",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "10",
+            "11",
+            "14",
+            "8",
+            "12"
+        ],
+        "tickets": [
+            [
+                "available",
+                "13"
+            ],
+            [
+                "available",
+                "9"
+            ],
+            [
+                "available",
+                "15"
+            ],
+            [
+                "available",
+                "16"
+            ],
+            [
+                "available",
+                "17"
+            ],
+            [
+                "available",
+                "18"
+            ],
+            [
+                "available",
+                "19"
+            ],
+            [
+                "available",
+                "10"
+            ],
+            [
+                "available",
+                "11"
+            ],
+            [
+                "available",
+                "14"
+            ],
+            [
+                "available",
+                "8"
+            ],
+            [
+                "available",
+                "12"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 480.23,
+        "format": "Eticket",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 478.19,
+        "ticket_costs": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "NU90Q2xNSDFmTml4WEF2Y3NhczhCVEljOE4yTi9HSUlhdlAzOVltS2pIMD0tLTJpeXFLeEFQUVJGOHpCOU5yTmhUa2c9PQ==--faffa82b7c58dff6f195d7d426c7687c7dedce54",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "lower level corner 120"
+    },
+    {
+        "id": 525968053,
+        "url": "/ticket_groups/525968053",
+        "type": "event",
+        "row": "22",
+        "section": "227",
+        "quantity": 3,
+        "available_quantity": 3,
+        "wholesale_price": 480.39,
+        "eticket": false,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": false,
+        "in_hand_on": "2019-06-13",
+        "remote_id": null,
+        "public_notes": null,
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-11-02T16:56:46Z",
+        "updated_at": "2018-11-23T16:19:30Z",
+        "splits": [
+            1,
+            3
+        ],
+        "ticket_states": {
+            "available": 3
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [],
+        "tickets": [
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 480.39,
+        "format": "Physical",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 466.4,
+        "ticket_costs": [
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 90 mins",
+        "signature": "WmdJSWIvTXpCeDdEaTgyOTA3UUtBNGVvSzg3VEtDa0hNLzJRNWpIbjcvVT0tLTV5cXNXSU9wZGppN2V1b01PMGIyL0E9PQ==--7da7680c6c484e959e9d67017cabbf082e25e0e0",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": true,
+        "tevo_section_name": "middle level corner 227"
+    },
+    {
+        "id": 525968028,
+        "url": "/ticket_groups/525968028",
+        "type": "event",
+        "row": "22",
+        "section": "208",
+        "quantity": 4,
+        "available_quantity": 4,
+        "wholesale_price": 480.39,
+        "eticket": false,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": false,
+        "in_hand_on": "2019-06-13",
+        "remote_id": null,
+        "public_notes": null,
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-11-02T16:56:45Z",
+        "updated_at": "2018-11-23T16:19:30Z",
+        "splits": [
+            2,
+            4
+        ],
+        "ticket_states": {
+            "available": 4
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [],
+        "tickets": [
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 480.39,
+        "format": "Physical",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 466.4,
+        "ticket_costs": [
+            null,
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 90 mins",
+        "signature": "TkFrSW5HSDhxVmhTYU8wL2hrKzRHSFJUeklHVlJqNzJLTFhxTy9BNGd6az0tLXMzZlpRaDJiVitsY3JTTk9SLzl1Tnc9PQ==--1d245aaa7c5fc707dc1f3f0d7d411b81949fcc38",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": true,
+        "tevo_section_name": "middle level corner 208"
+    },
+    {
+        "id": 533614156,
+        "url": "/ticket_groups/533614156",
+        "type": "event",
+        "row": "18",
+        "section": "105",
+        "quantity": 4,
+        "available_quantity": 4,
+        "wholesale_price": 482.25,
+        "eticket": true,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": null,
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-11-21T19:37:34Z",
+        "updated_at": "2018-12-26T20:06:36Z",
+        "splits": [
+            2,
+            4
+        ],
+        "ticket_states": {
+            "available": 4
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [
+            "10",
+            "11",
+            "13",
+            "12"
+        ],
+        "tickets": [
+            [
+                "available",
+                "10"
+            ],
+            [
+                "available",
+                "11"
+            ],
+            [
+                "available",
+                "13"
+            ],
+            [
+                "available",
+                "12"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 482.25,
+        "format": "Eticket",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 480.2,
+        "ticket_costs": [
+            null,
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "QzB1SVhKZ3ZJeWxpNmdPd2dZejBwa3R6bkQ1NDNocHFzaHV3ZXFCTlhOdz0tLURRNVlDV2JWQmNSSWFOTWtjVTVuMHc9PQ==--b580bab26cda1e86d8316241eb7d5ec155c16e41",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "lower level corner 105"
+    },
+    {
+        "id": 524708263,
+        "url": "/ticket_groups/524708263",
+        "type": "event",
+        "row": "15",
+        "section": "104",
+        "quantity": 3,
+        "available_quantity": 3,
+        "wholesale_price": 488.27,
+        "eticket": true,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": false,
+        "in_hand_on": "2019-06-17",
+        "remote_id": null,
+        "public_notes": "mobileqr Mobile Entry. Do not print these tickets. Scan your tickets from your mobile phone for this event. Mobile ticket: Scan your tickets from your mobile phone for this event. Do not print these tickets..",
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-10-31T17:19:16Z",
+        "updated_at": "2018-12-18T15:28:44Z",
+        "splits": [
+            1,
+            3
+        ],
+        "ticket_states": {
+            "available": 3
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [],
+        "tickets": [
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 488.27,
+        "format": "Eticket",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 474.05,
+        "ticket_costs": [
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "K1IyRjFtdXZjUUhwWWV5cmZNVTB3SVZKQjQ3VzVINUhTc0VqMWVDMzBaRT0tLWlLUmUwTGllT2czcWlkNTJoVnZQRWc9PQ==--945f6a04fe916ca652c1aff29655fd319ba7e500",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "lower level corner 104"
+    },
+    {
+        "id": 530791032,
+        "url": "/ticket_groups/530791032",
+        "type": "event",
+        "row": "9",
+        "section": "109",
+        "quantity": 2,
+        "available_quantity": 2,
+        "wholesale_price": 489.25,
+        "eticket": true,
+        "instant_delivery": true,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": "Side View",
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-11-13T20:22:54Z",
+        "updated_at": "2018-11-13T20:22:54Z",
+        "splits": [
+            2
+        ],
+        "ticket_states": {
+            "available": 2
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL"
+        ],
+        "seats": [],
+        "tickets": [
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 489.25,
+        "format": "Eticket",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 475,
+        "ticket_costs": [
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "SXlvbDRabnNPMmoyNmR1N2VyaHFzbHVxUTNxc3BUdE11UXNjVENaVmtDQT0tLXNDRDdPNWlVUyt6T2FqaXVHWk1ZWFE9PQ==--03034fb2c32c037d370d727f89b327de6655a382",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "lower level corner 109"
+    },
+    {
+        "id": 530791030,
+        "url": "/ticket_groups/530791030",
+        "type": "event",
+        "row": "8",
+        "section": "115",
+        "quantity": 2,
+        "available_quantity": 2,
+        "wholesale_price": 489.25,
+        "eticket": true,
+        "instant_delivery": true,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": "Side view.",
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-11-13T20:22:54Z",
+        "updated_at": "2018-11-13T20:22:54Z",
+        "splits": [
+            2
+        ],
+        "ticket_states": {
+            "available": 2
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL"
+        ],
+        "seats": [],
+        "tickets": [
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 489.25,
+        "format": "Eticket",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 475,
+        "ticket_costs": [
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "UUlEd3Q1R0E3enNnRW5YZU8zbmk3ODQ5eXloRENTM1EzdUZtYThKcFFwMD0tLS9mS2YvWVVkc3JhTzJSZ2hKekVEV1E9PQ==--fe2f7599fb71c7376333b20c16af638d6db03c01",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "lower level corner 115"
+    },
+    {
+        "id": 533614990,
+        "url": "/ticket_groups/533614990",
+        "type": "event",
+        "row": "21",
+        "section": "119",
+        "quantity": 6,
+        "available_quantity": 6,
+        "wholesale_price": 491.88,
+        "eticket": true,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": null,
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-11-21T19:38:59Z",
+        "updated_at": "2018-12-26T19:54:05Z",
+        "splits": [
+            1,
+            2,
+            3,
+            4,
+            6
+        ],
+        "ticket_states": {
+            "available": 6
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [
+            "11",
+            "12",
+            "10",
+            "9",
+            "8",
+            "7"
+        ],
+        "tickets": [
+            [
+                "available",
+                "11"
+            ],
+            [
+                "available",
+                "12"
+            ],
+            [
+                "available",
+                "10"
+            ],
+            [
+                "available",
+                "9"
+            ],
+            [
+                "available",
+                "8"
+            ],
+            [
+                "available",
+                "7"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 491.88,
+        "format": "Eticket",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 489.79,
+        "ticket_costs": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "MWl5eXFObzVKVWYrVVZrSVZ2Z2V6UmdEWkhyc1pvMTZWMkx4MUNKZ0VKST0tLWRGY0JERGxOcW1OemYzcGl5S3g3MVE9PQ==--c5180cc6d194fee609558a19047a0dc8b86ebb19",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "lower level corner 119"
+    },
+    {
+        "id": 533618924,
+        "url": "/ticket_groups/533618924",
+        "type": "event",
+        "row": "19",
+        "section": "120",
+        "quantity": 8,
+        "available_quantity": 8,
+        "wholesale_price": 499.43,
+        "eticket": true,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": null,
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-11-21T19:43:11Z",
+        "updated_at": "2018-12-20T23:53:30Z",
+        "splits": [
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            8
+        ],
+        "ticket_states": {
+            "available": 8
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [
+            "13",
+            "15",
+            "16",
+            "17",
+            "12",
+            "11",
+            "14",
+            "18"
+        ],
+        "tickets": [
+            [
+                "available",
+                "13"
+            ],
+            [
+                "available",
+                "15"
+            ],
+            [
+                "available",
+                "16"
+            ],
+            [
+                "available",
+                "17"
+            ],
+            [
+                "available",
+                "12"
+            ],
+            [
+                "available",
+                "11"
+            ],
+            [
+                "available",
+                "14"
+            ],
+            [
+                "available",
+                "18"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 499.43,
+        "format": "Eticket",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 497.31,
+        "ticket_costs": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "U2M3N3pzak1UOXBoWGI1UHpwem9LN3YxZmlDZWVxaHBBYitOb2N6ZnhzOD0tLW9uZENxTGx3SmpwS3dXQ3MrdFRnMGc9PQ==--6936c46165f0ea6311c5b91e828dc4d663f35a9b",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "lower level corner 120"
+    },
+    {
+        "id": 546690559,
+        "url": "/ticket_groups/546690559",
+        "type": "event",
+        "row": "18",
+        "section": "C",
+        "quantity": 6,
+        "available_quantity": 6,
+        "wholesale_price": 513.97,
+        "eticket": true,
+        "instant_delivery": true,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": null,
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-12-28T20:04:20Z",
+        "updated_at": "2018-12-28T20:04:20Z",
+        "splits": [
+            1,
+            2,
+            3,
+            4,
+            6
+        ],
+        "ticket_states": {
+            "available": 6
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [],
+        "tickets": [
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 513.97,
+        "format": "Eticket",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 499,
+        "ticket_costs": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "ZWZ0eTlMOE15OWtaVmpadkZSaDExSmNDNjlXQ2UrQk9pNzBSOGxTRGU2OD0tLUM0amVwNWJZaVNleHhuTEpZeU13YUE9PQ==--1bcc0bdfef5839d25170ec18a1ff628d93c72cf6",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "floor c"
+    },
+    {
+        "id": 541031670,
+        "url": "/ticket_groups/541031670",
+        "type": "event",
+        "row": "14",
+        "section": "116",
+        "quantity": 6,
+        "available_quantity": 6,
+        "wholesale_price": 513.97,
+        "eticket": false,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": null,
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-12-14T02:46:27Z",
+        "updated_at": "2018-12-14T02:46:27Z",
+        "splits": [
+            1,
+            2,
+            3,
+            4,
+            6
+        ],
+        "ticket_states": {
+            "available": 6
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [],
+        "tickets": [
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 513.97,
+        "format": "Physical",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 499,
+        "ticket_costs": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "dEVTMGxiWFJOdXMrK0FQOE55aUkrSm4rTEZ5OWtuWDdsNU1Va2Z2YmVycz0tLUlocVl5SGcxNXBBZUttcEVDek1tWWc9PQ==--056968c28fad2dd36ddcb48f47000958775e6648",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "lower level sideline 116"
+    },
+    {
+        "id": 533614161,
+        "url": "/ticket_groups/533614161",
+        "type": "event",
+        "row": "17",
+        "section": "104",
+        "quantity": 4,
+        "available_quantity": 4,
+        "wholesale_price": 515.5,
+        "eticket": true,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": null,
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-11-21T19:37:35Z",
+        "updated_at": "2018-12-26T20:06:37Z",
+        "splits": [
+            2,
+            4
+        ],
+        "ticket_states": {
+            "available": 4
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [
+            "7",
+            "8",
+            "9",
+            "10"
+        ],
+        "tickets": [
+            [
+                "available",
+                "7"
+            ],
+            [
+                "available",
+                "8"
+            ],
+            [
+                "available",
+                "9"
+            ],
+            [
+                "available",
+                "10"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 515.5,
+        "format": "Eticket",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 513.32,
+        "ticket_costs": [
+            null,
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "RGRpK0dRVzBrWHVpMnhqVmZFd0VrOFVlNTI5TFpMZStUc242eVhwSVI1UT0tLUowM05GOTY0Wmw2ci9XbFp1c0Q1YlE9PQ==--8cabaf023a59c682336d4aef30df7cefae78b66d",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "lower level corner 104"
+    },
+    {
+        "id": 533618930,
+        "url": "/ticket_groups/533618930",
+        "type": "event",
+        "row": "19",
+        "section": "101",
+        "quantity": 8,
+        "available_quantity": 8,
+        "wholesale_price": 518.64,
+        "eticket": true,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": null,
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-11-21T19:43:12Z",
+        "updated_at": "2018-12-20T23:53:30Z",
+        "splits": [
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            8
+        ],
+        "ticket_states": {
+            "available": 8
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [
+            "15",
+            "16",
+            "17",
+            "18",
+            "14",
+            "13",
+            "20",
+            "19"
+        ],
+        "tickets": [
+            [
+                "available",
+                "15"
+            ],
+            [
+                "available",
+                "16"
+            ],
+            [
+                "available",
+                "17"
+            ],
+            [
+                "available",
+                "18"
+            ],
+            [
+                "available",
+                "14"
+            ],
+            [
+                "available",
+                "13"
+            ],
+            [
+                "available",
+                "20"
+            ],
+            [
+                "available",
+                "19"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 518.64,
+        "format": "Eticket",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 516.44,
+        "ticket_costs": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "LzVaRU52Z0hBdi9jd2J6dVROdGhiaXN2VDgyOS9Pb1IvaTBIUEJqMG43cz0tLTF6cEl3ay9KR0VJd1BzWFN1dktGZmc9PQ==--f639057eb58b609235c8dcab6113e682313022d6",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "lower level baseline 101"
+    },
+    {
+        "id": 533614991,
+        "url": "/ticket_groups/533614991",
+        "type": "event",
+        "row": "22",
+        "section": "119",
+        "quantity": 16,
+        "available_quantity": 16,
+        "wholesale_price": 531.22,
+        "eticket": true,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": null,
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-11-21T19:39:00Z",
+        "updated_at": "2018-12-26T19:54:06Z",
+        "splits": [
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            16
+        ],
+        "ticket_states": {
+            "available": 16
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [
+            "24",
+            "23",
+            "25",
+            "14",
+            "27",
+            "22",
+            "21",
+            "20",
+            "19",
+            "18",
+            "17",
+            "13",
+            "16",
+            "15",
+            "28",
+            "26"
+        ],
+        "tickets": [
+            [
+                "available",
+                "24"
+            ],
+            [
+                "available",
+                "23"
+            ],
+            [
+                "available",
+                "25"
+            ],
+            [
+                "available",
+                "14"
+            ],
+            [
+                "available",
+                "27"
+            ],
+            [
+                "available",
+                "22"
+            ],
+            [
+                "available",
+                "21"
+            ],
+            [
+                "available",
+                "20"
+            ],
+            [
+                "available",
+                "19"
+            ],
+            [
+                "available",
+                "18"
+            ],
+            [
+                "available",
+                "17"
+            ],
+            [
+                "available",
+                "13"
+            ],
+            [
+                "available",
+                "16"
+            ],
+            [
+                "available",
+                "15"
+            ],
+            [
+                "available",
+                "28"
+            ],
+            [
+                "available",
+                "26"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 531.22,
+        "format": "Eticket",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 528.97,
+        "ticket_costs": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "Qkx0Z2dmcmJpUFloTnhjOFNWaWUvWE9XOWdMOXplbk5HbFROSUt0eWxldz0tLUlIS3psRHlmZnBFbHd5Z254ZjJVS3c9PQ==--c3bc4e97a30c3572c18fa3abe4fe067e6ac92d07",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "lower level corner 119"
+    },
+    {
+        "id": 533618935,
+        "url": "/ticket_groups/533618935",
+        "type": "event",
+        "row": "19",
+        "section": "103",
+        "quantity": 12,
+        "available_quantity": 12,
+        "wholesale_price": 537.85,
+        "eticket": true,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": null,
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-11-21T19:43:13Z",
+        "updated_at": "2018-12-20T23:53:30Z",
+        "splits": [
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+            12
+        ],
+        "ticket_states": {
+            "available": 12
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [
+            "12",
+            "9",
+            "10",
+            "11",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20"
+        ],
+        "tickets": [
+            [
+                "available",
+                "12"
+            ],
+            [
+                "available",
+                "9"
+            ],
+            [
+                "available",
+                "10"
+            ],
+            [
+                "available",
+                "11"
+            ],
+            [
+                "available",
+                "13"
+            ],
+            [
+                "available",
+                "14"
+            ],
+            [
+                "available",
+                "15"
+            ],
+            [
+                "available",
+                "16"
+            ],
+            [
+                "available",
+                "17"
+            ],
+            [
+                "available",
+                "18"
+            ],
+            [
+                "available",
+                "19"
+            ],
+            [
+                "available",
+                "20"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 537.85,
+        "format": "Eticket",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 535.57,
+        "ticket_costs": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "VlhYaGlieWlmSEZ1YW5CV2NKUDlwNnMxT2tjOXVVMVdTK2FSVWpOMnZPOD0tLVZ5WjFxaEV6ZHdsSkxoOFRIOTRxcHc9PQ==--a7e8698e208ab40054389b436247a831eacfee1c",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "lower level baseline 103"
+    },
+    {
+        "id": 525605724,
+        "url": "/ticket_groups/525605724",
+        "type": "event",
+        "row": "9",
+        "section": "1",
+        "quantity": 2,
+        "available_quantity": 2,
+        "wholesale_price": 538.18,
+        "eticket": true,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": null,
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-11-01T18:39:28Z",
+        "updated_at": "2018-12-07T19:48:55Z",
+        "splits": [
+            2
+        ],
+        "ticket_states": {
+            "available": 2
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL"
+        ],
+        "seats": [],
+        "tickets": [
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 538.18,
+        "format": "Eticket",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 522.5,
+        "ticket_costs": [
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "emc3V3gzUDRkNWw1R2NhVW9BQ09kb0plUWpROStEZ1hQU3RZWDh6amtUdz0tLVg1MU5XVDRVOW5EbkF3OHR6amlaS0E9PQ==--1f8fbfc027384411dd68d7941b1221d84218987d",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": true,
+        "tevo_section_name": "floor 1"
+    },
+    {
+        "id": 526277817,
+        "url": "/ticket_groups/526277817",
+        "type": "event",
+        "row": "Package",
+        "section": "Platinum-Fan",
+        "quantity": 24,
+        "available_quantity": 24,
+        "wholesale_price": 545.9,
+        "eticket": false,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": false,
+        "in_hand_on": "2019-06-11",
+        "remote_id": null,
+        "public_notes": "Platinum Fan Package includes: Reserved floor ticket (orders of three or more may be split) | Specially designed tour merchandise|",
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-11-03T01:16:41Z",
+        "updated_at": "2018-12-31T14:19:52Z",
+        "splits": [
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18,
+            19,
+            20,
+            21,
+            22,
+            24
+        ],
+        "ticket_states": {
+            "available": 24
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [
+            "357",
+            "350",
+            "351",
+            "352",
+            "353",
+            "354",
+            "355",
+            "356",
+            "358",
+            "359",
+            "360",
+            "361",
+            "362",
+            "363",
+            "364",
+            "365",
+            "366",
+            "367",
+            "368",
+            "369",
+            "370",
+            "371",
+            "372",
+            "373"
+        ],
+        "tickets": [
+            [
+                "available",
+                "357"
+            ],
+            [
+                "available",
+                "350"
+            ],
+            [
+                "available",
+                "351"
+            ],
+            [
+                "available",
+                "352"
+            ],
+            [
+                "available",
+                "353"
+            ],
+            [
+                "available",
+                "354"
+            ],
+            [
+                "available",
+                "355"
+            ],
+            [
+                "available",
+                "356"
+            ],
+            [
+                "available",
+                "358"
+            ],
+            [
+                "available",
+                "359"
+            ],
+            [
+                "available",
+                "360"
+            ],
+            [
+                "available",
+                "361"
+            ],
+            [
+                "available",
+                "362"
+            ],
+            [
+                "available",
+                "363"
+            ],
+            [
+                "available",
+                "364"
+            ],
+            [
+                "available",
+                "365"
+            ],
+            [
+                "available",
+                "366"
+            ],
+            [
+                "available",
+                "367"
+            ],
+            [
+                "available",
+                "368"
+            ],
+            [
+                "available",
+                "369"
+            ],
+            [
+                "available",
+                "370"
+            ],
+            [
+                "available",
+                "371"
+            ],
+            [
+                "available",
+                "372"
+            ],
+            [
+                "available",
+                "373"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 545.9,
+        "format": "Physical",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 530,
+        "ticket_costs": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "eTZTV1ZrTGVqMDRiaHcyWTlCN1JCMjVUMk1KU256TGVlNFdkQkU0WkNSST0tLWlpTDFha0NqUG5Ldk13ZWtkYkhWZVE9PQ==--85ba380b5495f7cf5a9c60500d2dcb9bea738312",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": true,
+        "tevo_section_name": "platinum-fan"
+    },
+    {
+        "id": 533614165,
+        "url": "/ticket_groups/533614165",
+        "type": "event",
+        "row": "16",
+        "section": "104",
+        "quantity": 4,
+        "available_quantity": 4,
+        "wholesale_price": 548.75,
+        "eticket": true,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": null,
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-11-21T19:37:35Z",
+        "updated_at": "2018-12-26T20:06:36Z",
+        "splits": [
+            2,
+            4
+        ],
+        "ticket_states": {
+            "available": 4
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [
+            "9",
+            "8",
+            "7",
+            "6"
+        ],
+        "tickets": [
+            [
+                "available",
+                "9"
+            ],
+            [
+                "available",
+                "8"
+            ],
+            [
+                "available",
+                "7"
+            ],
+            [
+                "available",
+                "6"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 548.75,
+        "format": "Eticket",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 546.43,
+        "ticket_costs": [
+            null,
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "ZVhNbXFqM2wzTUhvaFljaVpCcWFtcXV3NmRvWE4rc2M2NmFPWUwvcDcyZz0tLXplc2d1U2lBWlhIY2NZS1lHWlNnaGc9PQ==--fe3a53e3856855fba09077dd2ec5c4b061738a04",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "lower level corner 104"
+    },
+    {
+        "id": 533618932,
+        "url": "/ticket_groups/533618932",
+        "type": "event",
+        "row": "18",
+        "section": "101",
+        "quantity": 8,
+        "available_quantity": 8,
+        "wholesale_price": 557.04,
+        "eticket": true,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": null,
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-11-21T19:43:12Z",
+        "updated_at": "2018-12-20T23:53:30Z",
+        "splits": [
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            8
+        ],
+        "ticket_states": {
+            "available": 8
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [
+            "7",
+            "10",
+            "5",
+            "6",
+            "4",
+            "3",
+            "8",
+            "9"
+        ],
+        "tickets": [
+            [
+                "available",
+                "7"
+            ],
+            [
+                "available",
+                "10"
+            ],
+            [
+                "available",
+                "5"
+            ],
+            [
+                "available",
+                "6"
+            ],
+            [
+                "available",
+                "4"
+            ],
+            [
+                "available",
+                "3"
+            ],
+            [
+                "available",
+                "8"
+            ],
+            [
+                "available",
+                "9"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 557.04,
+        "format": "Eticket",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 554.69,
+        "ticket_costs": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "MW1aZzlaSHpCd2R1T0NrOWZPOXBaYUlzU2IxdlF5dUoyUisxVEpxV292Yz0tLWRmdS9wRzIyM2VvWkdUK3FGWVdpSnc9PQ==--471560f4254540d0313eef7e173a19126d5d312d",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "lower level baseline 101"
+    },
+    {
+        "id": 533614993,
+        "url": "/ticket_groups/533614993",
+        "type": "event",
+        "row": "22",
+        "section": "120",
+        "quantity": 24,
+        "available_quantity": 24,
+        "wholesale_price": 570.58,
+        "eticket": true,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": null,
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-11-21T19:39:00Z",
+        "updated_at": "2018-12-26T19:54:05Z",
+        "splits": [
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18,
+            19,
+            20,
+            21,
+            22,
+            24
+        ],
+        "ticket_states": {
+            "available": 24
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [
+            "15",
+            "14",
+            "13",
+            "11",
+            "10",
+            "12",
+            "9",
+            "7",
+            "8",
+            "6",
+            "3",
+            "4",
+            "5",
+            "24",
+            "23",
+            "26",
+            "22",
+            "21",
+            "20",
+            "19",
+            "18",
+            "25",
+            "17",
+            "16"
+        ],
+        "tickets": [
+            [
+                "available",
+                "15"
+            ],
+            [
+                "available",
+                "14"
+            ],
+            [
+                "available",
+                "13"
+            ],
+            [
+                "available",
+                "11"
+            ],
+            [
+                "available",
+                "10"
+            ],
+            [
+                "available",
+                "12"
+            ],
+            [
+                "available",
+                "9"
+            ],
+            [
+                "available",
+                "7"
+            ],
+            [
+                "available",
+                "8"
+            ],
+            [
+                "available",
+                "6"
+            ],
+            [
+                "available",
+                "3"
+            ],
+            [
+                "available",
+                "4"
+            ],
+            [
+                "available",
+                "5"
+            ],
+            [
+                "available",
+                "24"
+            ],
+            [
+                "available",
+                "23"
+            ],
+            [
+                "available",
+                "26"
+            ],
+            [
+                "available",
+                "22"
+            ],
+            [
+                "available",
+                "21"
+            ],
+            [
+                "available",
+                "20"
+            ],
+            [
+                "available",
+                "19"
+            ],
+            [
+                "available",
+                "18"
+            ],
+            [
+                "available",
+                "25"
+            ],
+            [
+                "available",
+                "17"
+            ],
+            [
+                "available",
+                "16"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 570.58,
+        "format": "Eticket",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 568.16,
+        "ticket_costs": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "b2VOUDNseUpFRWsvUnJMRmF0Yi9xdkZJOGdvdWJiKzk5R21IRWwxdC9sdz0tLXhVSFZIZU0weFhiLzdZeVV5TUZaOGc9PQ==--3cf2f79f6bc945392afd46aeb3dd2e0e6106dff9",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "lower level corner 120"
+    },
+    {
+        "id": 526278023,
+        "url": "/ticket_groups/526278023",
+        "type": "event",
+        "row": "Package",
+        "section": "Silver-Fan",
+        "quantity": 24,
+        "available_quantity": 24,
+        "wholesale_price": 571.65,
+        "eticket": false,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": false,
+        "in_hand_on": "2019-06-11",
+        "remote_id": null,
+        "public_notes": "Silver Fan Package includes: Reserved lower level (non-Floor) ticket (Orders of three or more may be split) | Specially designed tour merchandise |",
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-11-03T01:16:53Z",
+        "updated_at": "2018-12-30T12:09:55Z",
+        "splits": [
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18,
+            19,
+            20,
+            21,
+            22,
+            24
+        ],
+        "ticket_states": {
+            "available": 24
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [
+            "652",
+            "650",
+            "651",
+            "653",
+            "654",
+            "655",
+            "656",
+            "657",
+            "658",
+            "659",
+            "660",
+            "661",
+            "662",
+            "663",
+            "664",
+            "665",
+            "666",
+            "667",
+            "668",
+            "669",
+            "670",
+            "671",
+            "672",
+            "673"
+        ],
+        "tickets": [
+            [
+                "available",
+                "652"
+            ],
+            [
+                "available",
+                "650"
+            ],
+            [
+                "available",
+                "651"
+            ],
+            [
+                "available",
+                "653"
+            ],
+            [
+                "available",
+                "654"
+            ],
+            [
+                "available",
+                "655"
+            ],
+            [
+                "available",
+                "656"
+            ],
+            [
+                "available",
+                "657"
+            ],
+            [
+                "available",
+                "658"
+            ],
+            [
+                "available",
+                "659"
+            ],
+            [
+                "available",
+                "660"
+            ],
+            [
+                "available",
+                "661"
+            ],
+            [
+                "available",
+                "662"
+            ],
+            [
+                "available",
+                "663"
+            ],
+            [
+                "available",
+                "664"
+            ],
+            [
+                "available",
+                "665"
+            ],
+            [
+                "available",
+                "666"
+            ],
+            [
+                "available",
+                "667"
+            ],
+            [
+                "available",
+                "668"
+            ],
+            [
+                "available",
+                "669"
+            ],
+            [
+                "available",
+                "670"
+            ],
+            [
+                "available",
+                "671"
+            ],
+            [
+                "available",
+                "672"
+            ],
+            [
+                "available",
+                "673"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 571.65,
+        "format": "Physical",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 555,
+        "ticket_costs": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "SHdSK2dpV09UNWhFRW1tdUdiUEJiVmlJVm14R0o2T2RhWDBHbEpmL1hvRT0tLStwM0cvODdqb3F5OFk0RllzMmQzSnc9PQ==--48579c0f0fca0ef7f69938f55bf642c69c2df0e2",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": true,
+        "tevo_section_name": "silver-fan"
+    },
+    {
+        "id": 533618931,
+        "url": "/ticket_groups/533618931",
+        "type": "event",
+        "row": "15",
+        "section": "104",
+        "quantity": 5,
+        "available_quantity": 5,
+        "wholesale_price": 576.25,
+        "eticket": true,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": null,
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-11-21T19:43:12Z",
+        "updated_at": "2018-12-24T22:25:47Z",
+        "splits": [
+            1,
+            2,
+            3,
+            5
+        ],
+        "ticket_states": {
+            "available": 5
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [
+            "15",
+            "14",
+            "13",
+            "17",
+            "16"
+        ],
+        "tickets": [
+            [
+                "available",
+                "15"
+            ],
+            [
+                "available",
+                "14"
+            ],
+            [
+                "available",
+                "13"
+            ],
+            [
+                "available",
+                "17"
+            ],
+            [
+                "available",
+                "16"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 576.25,
+        "format": "Eticket",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 573.82,
+        "ticket_costs": [
+            null,
+            null,
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "eWs3V2RhM1k1T0wwVEpkYXFmaEtpRG1rYnlhVHNOREk0MUhVd1pGbzBzQT0tLTVoeGlKaHRvRE91NFBPOWhpWUpKbmc9PQ==--ae10ba4cf672ef163ed1b34c09e5279c40f88919",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "lower level corner 104"
+    },
+    {
+        "id": 543502189,
+        "url": "/ticket_groups/543502189",
+        "type": "event",
+        "row": "11",
+        "section": "118",
+        "quantity": 2,
+        "available_quantity": 2,
+        "wholesale_price": 595.34,
+        "eticket": false,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": null,
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-12-20T01:10:38Z",
+        "updated_at": "2018-12-31T17:42:53Z",
+        "splits": [
+            2
+        ],
+        "ticket_states": {
+            "available": 2
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL"
+        ],
+        "seats": [],
+        "tickets": [
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 595.34,
+        "format": "Physical",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 578,
+        "ticket_costs": [
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "RGZVTUFYeW91VHJKL1AxcUpRSTFpYjVDcC9CWmZlb2hVTVRZekpiMWFnRT0tLURTWCtudDAvVTI2R1BaMnZCNHBHNEE9PQ==--c6c720b41b1c47a748b5aa164da1f55bd7143ea7",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": true,
+        "tevo_section_name": "lower level sideline 118"
+    },
+    {
+        "id": 536678381,
+        "url": "/ticket_groups/536678381",
+        "type": "event",
+        "row": "13",
+        "section": "118",
+        "quantity": 6,
+        "available_quantity": 6,
+        "wholesale_price": 596.37,
+        "eticket": false,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": null,
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-11-30T23:49:25Z",
+        "updated_at": "2018-12-31T17:42:57Z",
+        "splits": [
+            1,
+            2,
+            3,
+            4,
+            6
+        ],
+        "ticket_states": {
+            "available": 6
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [],
+        "tickets": [
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 596.37,
+        "format": "Physical",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 579,
+        "ticket_costs": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "cWtsVFRxWk9QUktSc1lvNEFsUXJtS2cwV3c2dU9YRTB6bmxhaVBaSGYvdz0tLVNHZm5oQnc0YXFIY0xmenZDdUdIMFE9PQ==--b292929f73f53e3bca6a631251d731830232421d",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": true,
+        "tevo_section_name": "lower level sideline 118"
+    },
+    {
+        "id": 533614984,
+        "url": "/ticket_groups/533614984",
+        "type": "event",
+        "row": "21",
+        "section": "120",
+        "quantity": 16,
+        "available_quantity": 16,
+        "wholesale_price": 609.93,
+        "eticket": true,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": null,
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-11-21T19:38:58Z",
+        "updated_at": "2018-12-26T19:54:05Z",
+        "splits": [
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            16
+        ],
+        "ticket_states": {
+            "available": 16
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [
+            "18",
+            "16",
+            "15",
+            "14",
+            "13",
+            "12",
+            "11",
+            "10",
+            "9",
+            "8",
+            "7",
+            "6",
+            "5",
+            "4",
+            "19",
+            "17"
+        ],
+        "tickets": [
+            [
+                "available",
+                "18"
+            ],
+            [
+                "available",
+                "16"
+            ],
+            [
+                "available",
+                "15"
+            ],
+            [
+                "available",
+                "14"
+            ],
+            [
+                "available",
+                "13"
+            ],
+            [
+                "available",
+                "12"
+            ],
+            [
+                "available",
+                "11"
+            ],
+            [
+                "available",
+                "10"
+            ],
+            [
+                "available",
+                "9"
+            ],
+            [
+                "available",
+                "8"
+            ],
+            [
+                "available",
+                "7"
+            ],
+            [
+                "available",
+                "6"
+            ],
+            [
+                "available",
+                "5"
+            ],
+            [
+                "available",
+                "4"
+            ],
+            [
+                "available",
+                "19"
+            ],
+            [
+                "available",
+                "17"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 609.93,
+        "format": "Eticket",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 607.35,
+        "ticket_costs": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "TTFOZXM4M2Zqazh6NkFpQWhvU2xVdjRuOEo1dmdmOVlGY0VoeWRLem1kYz0tLTRIWUpIcnZXTmd0VHQrdktZL2FQeUE9PQ==--45616243f0ff83bfe85986c4dd0c9aee49d65e9d",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "lower level corner 120"
+    },
+    {
+        "id": 546690563,
+        "url": "/ticket_groups/546690563",
+        "type": "event",
+        "row": "17",
+        "section": "C",
+        "quantity": 7,
+        "available_quantity": 7,
+        "wholesale_price": 618,
+        "eticket": true,
+        "instant_delivery": true,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": null,
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-12-28T20:04:21Z",
+        "updated_at": "2018-12-28T20:04:22Z",
+        "splits": [
+            1,
+            2,
+            3,
+            4,
+            5,
+            7
+        ],
+        "ticket_states": {
+            "available": 7
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [],
+        "tickets": [
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 618,
+        "format": "Eticket",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 600,
+        "ticket_costs": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "WVhzU3pmeVorQjhDQVYrYWM2Z2p3bWJML3F5ck53NG55VHV2SEhnQmZzQT0tLTF2R2xncFJSeTB5cVlyd2ZFbGxWRUE9PQ==--bc9c6c0838a780b2a2d59b20ea6db0678bb69a5a",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "floor c"
+    },
+    {
+        "id": 540031144,
+        "url": "/ticket_groups/540031144",
+        "type": "event",
+        "row": "3",
+        "section": "1",
+        "quantity": 4,
+        "available_quantity": 4,
+        "wholesale_price": 648.9,
+        "eticket": true,
+        "instant_delivery": true,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": "eTicket",
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-12-11T11:45:34Z",
+        "updated_at": "2019-01-02T00:07:23Z",
+        "splits": [
+            2,
+            4
+        ],
+        "ticket_states": {
+            "available": 4
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [],
+        "tickets": [
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 648.9,
+        "format": "Eticket",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 630,
+        "ticket_costs": [
+            null,
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "a01QR29GWTFZRVZLcjZoTnl6d1o0eUZ1VHVKb2Nnc2VVRWdvNTRCdWhPYz0tLTM2VnJ1WGk0TzQvbEg5OXEyV0w1S1E9PQ==--1a691525f7bece6ec2f8af39bf7603b24fa69f69",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "floor 1"
+    },
+    {
+        "id": 539976367,
+        "url": "/ticket_groups/539976367",
+        "type": "event",
+        "row": "2",
+        "section": "3",
+        "quantity": 2,
+        "available_quantity": 2,
+        "wholesale_price": 669.5,
+        "eticket": true,
+        "instant_delivery": true,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": "eTicket",
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-12-11T03:17:16Z",
+        "updated_at": "2019-01-02T00:07:23Z",
+        "splits": [
+            2
+        ],
+        "ticket_states": {
+            "available": 2
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL"
+        ],
+        "seats": [],
+        "tickets": [
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 669.5,
+        "format": "Eticket",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 650,
+        "ticket_costs": [
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "U296R3NxcW1IMUJNaVBJamxBbzBuMlkvWkRKNm14RzZRc1FxRHllSTV3OD0tLXIrdU9zUWpNOW5uNHBlUVJRcktUYXc9PQ==--83cf2aa4cbf3cb8e33e497012b2faab7b45b8a1e",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "floor 3"
+    },
+    {
+        "id": 526277770,
+        "url": "/ticket_groups/526277770",
+        "type": "event",
+        "row": "Package",
+        "section": "Platinum-Deluxe",
+        "quantity": 24,
+        "available_quantity": 24,
+        "wholesale_price": 705.55,
+        "eticket": false,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": false,
+        "in_hand_on": "2019-06-11",
+        "remote_id": null,
+        "public_notes": "Platinum Deluxe Package includes: Reserved floor ticket (orders of three or more may be split) | Private pre-show hospitality featuring food and drinks | Specially designed tour merchandise| Detailed itinerary |",
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-11-03T01:16:38Z",
+        "updated_at": "2018-12-31T14:19:51Z",
+        "splits": [
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18,
+            19,
+            20,
+            21,
+            22,
+            24
+        ],
+        "ticket_states": {
+            "available": 24
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [
+            "313",
+            "312",
+            "311",
+            "310",
+            "309",
+            "308",
+            "318",
+            "319",
+            "307",
+            "306",
+            "317",
+            "304",
+            "303",
+            "302",
+            "301",
+            "300",
+            "320",
+            "321",
+            "322",
+            "323",
+            "305",
+            "316",
+            "315",
+            "314"
+        ],
+        "tickets": [
+            [
+                "available",
+                "313"
+            ],
+            [
+                "available",
+                "312"
+            ],
+            [
+                "available",
+                "311"
+            ],
+            [
+                "available",
+                "310"
+            ],
+            [
+                "available",
+                "309"
+            ],
+            [
+                "available",
+                "308"
+            ],
+            [
+                "available",
+                "318"
+            ],
+            [
+                "available",
+                "319"
+            ],
+            [
+                "available",
+                "307"
+            ],
+            [
+                "available",
+                "306"
+            ],
+            [
+                "available",
+                "317"
+            ],
+            [
+                "available",
+                "304"
+            ],
+            [
+                "available",
+                "303"
+            ],
+            [
+                "available",
+                "302"
+            ],
+            [
+                "available",
+                "301"
+            ],
+            [
+                "available",
+                "300"
+            ],
+            [
+                "available",
+                "320"
+            ],
+            [
+                "available",
+                "321"
+            ],
+            [
+                "available",
+                "322"
+            ],
+            [
+                "available",
+                "323"
+            ],
+            [
+                "available",
+                "305"
+            ],
+            [
+                "available",
+                "316"
+            ],
+            [
+                "available",
+                "315"
+            ],
+            [
+                "available",
+                "314"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 705.55,
+        "format": "Physical",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 685,
+        "ticket_costs": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "MWdEMEh0ZFg5aTRKWEFqaWxTMGRzTjhKWHFObkc4OTBZNTdCUGlzcVRtbz0tLXRHVW9oTGxhMjFrYy9wN3ZPRFNaSnc9PQ==--201b8bcb8907fd7b7c58f288b5b3c812630dc084",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": true,
+        "tevo_section_name": "platinum-deluxe"
+    },
+    {
+        "id": 526277936,
+        "url": "/ticket_groups/526277936",
+        "type": "event",
+        "row": "Package",
+        "section": "Gold-Fan",
+        "quantity": 24,
+        "available_quantity": 24,
+        "wholesale_price": 705.55,
+        "eticket": false,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": false,
+        "in_hand_on": "2019-06-11",
+        "remote_id": null,
+        "public_notes": "Gold Fan Package includes: Premium reserved lower level (non-Floor) ticket located in the three sections closest to stage (orders of three or more may be split) | Specially designed tour merchandise|",
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-11-03T01:16:48Z",
+        "updated_at": "2018-12-23T12:56:12Z",
+        "splits": [
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18,
+            19,
+            20,
+            21,
+            22,
+            24
+        ],
+        "ticket_states": {
+            "available": 24
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [
+            "551",
+            "566",
+            "565",
+            "567",
+            "568",
+            "569",
+            "570",
+            "571",
+            "572",
+            "573",
+            "564",
+            "563",
+            "562",
+            "561",
+            "560",
+            "559",
+            "558",
+            "557",
+            "556",
+            "555",
+            "554",
+            "553",
+            "552",
+            "550"
+        ],
+        "tickets": [
+            [
+                "available",
+                "551"
+            ],
+            [
+                "available",
+                "566"
+            ],
+            [
+                "available",
+                "565"
+            ],
+            [
+                "available",
+                "567"
+            ],
+            [
+                "available",
+                "568"
+            ],
+            [
+                "available",
+                "569"
+            ],
+            [
+                "available",
+                "570"
+            ],
+            [
+                "available",
+                "571"
+            ],
+            [
+                "available",
+                "572"
+            ],
+            [
+                "available",
+                "573"
+            ],
+            [
+                "available",
+                "564"
+            ],
+            [
+                "available",
+                "563"
+            ],
+            [
+                "available",
+                "562"
+            ],
+            [
+                "available",
+                "561"
+            ],
+            [
+                "available",
+                "560"
+            ],
+            [
+                "available",
+                "559"
+            ],
+            [
+                "available",
+                "558"
+            ],
+            [
+                "available",
+                "557"
+            ],
+            [
+                "available",
+                "556"
+            ],
+            [
+                "available",
+                "555"
+            ],
+            [
+                "available",
+                "554"
+            ],
+            [
+                "available",
+                "553"
+            ],
+            [
+                "available",
+                "552"
+            ],
+            [
+                "available",
+                "550"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 705.55,
+        "format": "Physical",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 685,
+        "ticket_costs": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "dytjaG1hdjFlbnhqWWk3MCtzRjY2WDIxNjZkQXNEUkJxTDh2M0xOT3d1bz0tLVpwUW9MUzdjY1cySk54UFgrYjhzUXc9PQ==--ab414dbca46ede63fd54bc662a5331898cc38b96",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": true,
+        "tevo_section_name": "gold-fan"
+    },
+    {
+        "id": 525927865,
+        "url": "/ticket_groups/525927865",
+        "type": "event",
+        "row": "10",
+        "section": "115",
+        "quantity": 2,
+        "available_quantity": 2,
+        "wholesale_price": 719.97,
+        "eticket": true,
+        "instant_delivery": true,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": "Side View",
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-11-02T15:57:43Z",
+        "updated_at": "2018-12-05T17:18:41Z",
+        "splits": [
+            2
+        ],
+        "ticket_states": {
+            "available": 2
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL"
+        ],
+        "seats": [],
+        "tickets": [
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 719.97,
+        "format": "Eticket",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 699,
+        "ticket_costs": [
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "VlcwTllYOU8wbUFhTUtsZnExYjVGN3Rzakk0MUZKTGdDZEVpa0Rpd3NNYz0tLTZuVkh3U2ZXNVNTZERSSSt2K1VyRXc9PQ==--9bedee08e819b4160db0af71997665c139f2a4fa",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": true,
+        "tevo_section_name": "lower level corner 115"
+    },
+    {
+        "id": 539976368,
+        "url": "/ticket_groups/539976368",
+        "type": "event",
+        "row": "2",
+        "section": "1",
+        "quantity": 2,
+        "available_quantity": 2,
+        "wholesale_price": 721,
+        "eticket": true,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": false,
+        "in_hand_on": "2019-06-18",
+        "remote_id": null,
+        "public_notes": "eTicket",
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-12-11T03:17:16Z",
+        "updated_at": "2018-12-11T03:17:16Z",
+        "splits": [
+            2
+        ],
+        "ticket_states": {
+            "available": 2
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL"
+        ],
+        "seats": [],
+        "tickets": [
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 721,
+        "format": "Eticket",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 700,
+        "ticket_costs": [
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "aWR6N3I4OEoyb2Z0dHJLaFZZazdrQ3RZMUhHSDlObmlvR2tpVWFyekFOQT0tLVZndXFOK3djS1hvcENnWCt2MTN2UkE9PQ==--2fb5d83003b78d10a94b3480995392e7739260c9",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "floor 1"
+    },
+    {
+        "id": 526277987,
+        "url": "/ticket_groups/526277987",
+        "type": "event",
+        "row": "Package",
+        "section": "Silver-Deluxe",
+        "quantity": 24,
+        "available_quantity": 24,
+        "wholesale_price": 731.3,
+        "eticket": false,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": false,
+        "in_hand_on": "2019-06-11",
+        "remote_id": null,
+        "public_notes": "Silver Deluxe Package includes: Reserved lower level (non-Floor) ticket (orders of three or more may be split) | Private pre-show hospitality featuring food and drinks | Specially designed tour merchandise | Detailed itinerary |",
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-11-03T01:16:51Z",
+        "updated_at": "2018-12-30T12:09:55Z",
+        "splits": [
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18,
+            19,
+            20,
+            21,
+            22,
+            24
+        ],
+        "ticket_states": {
+            "available": 24
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [
+            "623",
+            "603",
+            "604",
+            "605",
+            "606",
+            "607",
+            "608",
+            "609",
+            "610",
+            "611",
+            "612",
+            "602",
+            "601",
+            "600",
+            "613",
+            "614",
+            "615",
+            "616",
+            "617",
+            "618",
+            "619",
+            "620",
+            "621",
+            "622"
+        ],
+        "tickets": [
+            [
+                "available",
+                "623"
+            ],
+            [
+                "available",
+                "603"
+            ],
+            [
+                "available",
+                "604"
+            ],
+            [
+                "available",
+                "605"
+            ],
+            [
+                "available",
+                "606"
+            ],
+            [
+                "available",
+                "607"
+            ],
+            [
+                "available",
+                "608"
+            ],
+            [
+                "available",
+                "609"
+            ],
+            [
+                "available",
+                "610"
+            ],
+            [
+                "available",
+                "611"
+            ],
+            [
+                "available",
+                "612"
+            ],
+            [
+                "available",
+                "602"
+            ],
+            [
+                "available",
+                "601"
+            ],
+            [
+                "available",
+                "600"
+            ],
+            [
+                "available",
+                "613"
+            ],
+            [
+                "available",
+                "614"
+            ],
+            [
+                "available",
+                "615"
+            ],
+            [
+                "available",
+                "616"
+            ],
+            [
+                "available",
+                "617"
+            ],
+            [
+                "available",
+                "618"
+            ],
+            [
+                "available",
+                "619"
+            ],
+            [
+                "available",
+                "620"
+            ],
+            [
+                "available",
+                "621"
+            ],
+            [
+                "available",
+                "622"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 731.3,
+        "format": "Physical",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 710,
+        "ticket_costs": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "QXI5MkNDdzlPMjZ3YkxBMjZ1S1p5L2VkM2hwT2NSbzRSc242S3JSSGo3WT0tLVp3RnVBRGxXVVNYN3JUWmk5NDdFSlE9PQ==--4d4fc8c28fcb0bc91c4bf336a02252301ae276f9",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": true,
+        "tevo_section_name": "silver-deluxe"
+    },
+    {
+        "id": 541118535,
+        "url": "/ticket_groups/541118535",
+        "type": "event",
+        "row": "13",
+        "section": "116",
+        "quantity": 4,
+        "available_quantity": 4,
+        "wholesale_price": 795.16,
+        "eticket": false,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": null,
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-12-14T14:38:35Z",
+        "updated_at": "2018-12-31T17:43:12Z",
+        "splits": [
+            2,
+            4
+        ],
+        "ticket_states": {
+            "available": 4
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [],
+        "tickets": [
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 795.16,
+        "format": "Physical",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 772,
+        "ticket_costs": [
+            null,
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "THBzQWh5TFFHTkZIbjFSRkkvbGVqYUJvQWxyNGl4ZmZFT0NQdzJmeXpvYz0tLWl6dHFTa1dOU09xMUVQOENBRGhCNWc9PQ==--2a04712e0cf8eb3c67455a66baee427fc4268de9",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": true,
+        "tevo_section_name": "lower level sideline 116"
+    },
+    {
+        "id": 548276400,
+        "url": "/ticket_groups/548276400",
+        "type": "event",
+        "row": "12",
+        "section": "107",
+        "quantity": 4,
+        "available_quantity": 4,
+        "wholesale_price": 800.31,
+        "eticket": true,
+        "instant_delivery": true,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": null,
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2019-01-02T19:50:36Z",
+        "updated_at": "2019-01-02T19:50:36Z",
+        "splits": [
+            2,
+            4
+        ],
+        "ticket_states": {
+            "available": 4
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [
+            "9",
+            "10",
+            "11",
+            "12"
+        ],
+        "tickets": [
+            [
+                "available",
+                "9"
+            ],
+            [
+                "available",
+                "10"
+            ],
+            [
+                "available",
+                "11"
+            ],
+            [
+                "available",
+                "12"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 800.31,
+        "format": "Eticket",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 777,
+        "ticket_costs": [
+            null,
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "OURmdjV4aGplOU15SnQxaVVOc0szbE55ekxVdU5KZHc0ZkxMcnZZMGhVbz0tLVJCd21sQWdHdEpMc3pXSng5ZWZxS2c9PQ==--e24c0ee2d6f3f780a35e0070d42440313475f77e",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": true,
+        "tevo_section_name": "lower level sideline 107"
+    },
+    {
+        "id": 544183773,
+        "url": "/ticket_groups/544183773",
+        "type": "event",
+        "row": "19",
+        "section": "107",
+        "quantity": 2,
+        "available_quantity": 2,
+        "wholesale_price": 827.3,
+        "eticket": true,
+        "instant_delivery": true,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": null,
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-12-21T16:27:51Z",
+        "updated_at": "2018-12-21T16:27:51Z",
+        "splits": [
+            2
+        ],
+        "ticket_states": {
+            "available": 2
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL"
+        ],
+        "seats": [],
+        "tickets": [
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 827.3,
+        "format": "Eticket",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 803.2,
+        "ticket_costs": [
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "cmY4bHpxUEM3R2laN0xsa3dYbWxTKzlVUjhRUGFZSy9XdGliKzlRc21CWT0tLUpFc0dvNENabkpCOWQ3cUE1WDhac3c9PQ==--f5a5549666aef8070463ac385031c6f8d2db3dc3",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": true,
+        "tevo_section_name": "lower level sideline 107"
+    },
+    {
+        "id": 539771463,
+        "url": "/ticket_groups/539771463",
+        "type": "event",
+        "row": "5",
+        "section": "FLOOR D",
+        "quantity": 4,
+        "available_quantity": 4,
+        "wholesale_price": 856.96,
+        "eticket": false,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": null,
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-12-10T17:43:00Z",
+        "updated_at": "2018-12-10T17:43:00Z",
+        "splits": [
+            2,
+            4
+        ],
+        "ticket_states": {
+            "available": 4
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [
+            "7",
+            "10",
+            "9",
+            "8"
+        ],
+        "tickets": [
+            [
+                "available",
+                "7"
+            ],
+            [
+                "available",
+                "10"
+            ],
+            [
+                "available",
+                "9"
+            ],
+            [
+                "available",
+                "8"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 856.96,
+        "format": "Physical",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 832,
+        "ticket_costs": [
+            null,
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "MWRMT3NMaU9UZG9TOGdDRm8rdm1iMS9KbXRHTEFaUFZaUGdlNmQ3VFRvaz0tLWY3dkJCQjdEdVFpR21zQk91QkJNK3c9PQ==--fb85c7aeb4b559900e4c09548c51216b3ae0bcd4",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "floor d"
+    },
+    {
+        "id": 526277899,
+        "url": "/ticket_groups/526277899",
+        "type": "event",
+        "row": "Package",
+        "section": "Gold-Deluxe",
+        "quantity": 24,
+        "available_quantity": 24,
+        "wholesale_price": 875.5,
+        "eticket": false,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": false,
+        "in_hand_on": "2019-06-11",
+        "remote_id": null,
+        "public_notes": "Gold Deluxe Package includes: Premium reserved lower level (non-Floor) ticket located in the three sections closest to stage (orders of three or more may be split) | Private pre-show hospitality featuring food and drinks | Specially designed tour merchandise | Detailed itinerary |",
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-11-03T01:16:45Z",
+        "updated_at": "2018-12-23T12:56:11Z",
+        "splits": [
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18,
+            19,
+            20,
+            21,
+            22,
+            24
+        ],
+        "ticket_states": {
+            "available": 24
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [
+            "450",
+            "463",
+            "462",
+            "461",
+            "460",
+            "459",
+            "458",
+            "457",
+            "456",
+            "455",
+            "454",
+            "464",
+            "465",
+            "466",
+            "467",
+            "468",
+            "469",
+            "470",
+            "453",
+            "471",
+            "472",
+            "473",
+            "452",
+            "451"
+        ],
+        "tickets": [
+            [
+                "available",
+                "450"
+            ],
+            [
+                "available",
+                "463"
+            ],
+            [
+                "available",
+                "462"
+            ],
+            [
+                "available",
+                "461"
+            ],
+            [
+                "available",
+                "460"
+            ],
+            [
+                "available",
+                "459"
+            ],
+            [
+                "available",
+                "458"
+            ],
+            [
+                "available",
+                "457"
+            ],
+            [
+                "available",
+                "456"
+            ],
+            [
+                "available",
+                "455"
+            ],
+            [
+                "available",
+                "454"
+            ],
+            [
+                "available",
+                "464"
+            ],
+            [
+                "available",
+                "465"
+            ],
+            [
+                "available",
+                "466"
+            ],
+            [
+                "available",
+                "467"
+            ],
+            [
+                "available",
+                "468"
+            ],
+            [
+                "available",
+                "469"
+            ],
+            [
+                "available",
+                "470"
+            ],
+            [
+                "available",
+                "453"
+            ],
+            [
+                "available",
+                "471"
+            ],
+            [
+                "available",
+                "472"
+            ],
+            [
+                "available",
+                "473"
+            ],
+            [
+                "available",
+                "452"
+            ],
+            [
+                "available",
+                "451"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 875.5,
+        "format": "Physical",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 850,
+        "ticket_costs": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "ajI0NzFDWnpOMXZqd25GVGdsOWZUVFQ1MzM5VFJsVnFQWFp1RDBQUjVXMD0tLS9NNThGb0NKKzg4YnFNRUl1c1JUTHc9PQ==--82e8018761a6e080953e4f572dc38a522e1849e7",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": true,
+        "tevo_section_name": "gold-deluxe"
+    },
+    {
+        "id": 545635115,
+        "url": "/ticket_groups/545635115",
+        "type": "event",
+        "row": "7",
+        "section": "D",
+        "quantity": 4,
+        "available_quantity": 4,
+        "wholesale_price": 905.37,
+        "eticket": false,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": null,
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-12-26T22:50:47Z",
+        "updated_at": "2018-12-26T22:50:47Z",
+        "splits": [
+            2,
+            4
+        ],
+        "ticket_states": {
+            "available": 4
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [],
+        "tickets": [
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 905.37,
+        "format": "Physical",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 879,
+        "ticket_costs": [
+            null,
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "eldrSm9oZGwxU2N2MnBmZHE4dXkzd2M5NWMybmZSd0dad21ld1VnS3JHZz0tLVM0WXc5RWpqQ0RNN2wwa1pKWVIwOEE9PQ==--54d40e216c88a30cb21463dc02c87d2c0d5b8a41",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "floor d"
+    },
+    {
+        "id": 533370188,
+        "url": "/ticket_groups/533370188",
+        "type": "event",
+        "row": "8",
+        "section": "107",
+        "quantity": 3,
+        "available_quantity": 3,
+        "wholesale_price": 927,
+        "eticket": false,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": null,
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-11-20T23:52:15Z",
+        "updated_at": "2018-11-23T04:31:34Z",
+        "splits": [
+            1,
+            3
+        ],
+        "ticket_states": {
+            "available": 3
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [],
+        "tickets": [
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 927,
+        "format": "Physical",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 900,
+        "ticket_costs": [
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "RXdybnpkcE1NYnI3cm5uTVlzTmh1Mk5nSzNNRHF3RnVyOXFHMkdEWkFmWT0tLUZkMEk1dXNJbHQzVHRiSUVQNU1QMWc9PQ==--e69203f57b781e62ec0344ae97b25e300b6f1b1c",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "lower level sideline 107"
+    },
+    {
+        "id": 538214103,
+        "url": "/ticket_groups/538214103",
+        "type": "event",
+        "row": "6",
+        "section": "F",
+        "quantity": 8,
+        "available_quantity": 8,
+        "wholesale_price": 1024.85,
+        "eticket": true,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": true,
+        "in_hand_on": null,
+        "remote_id": null,
+        "public_notes": null,
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-12-06T01:00:58Z",
+        "updated_at": "2018-12-06T01:00:59Z",
+        "splits": [
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            8
+        ],
+        "ticket_states": {
+            "available": 8
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [],
+        "tickets": [
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 1024.85,
+        "format": "Eticket",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 995,
+        "ticket_costs": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "YjQvY0tMSmg4NmR4Wnp5NWx5YnFGWHd2Q205aU9VTHlERk0zblViS2ZxMD0tLWhpSjJaM015Q1B0Y3l1eTJaUjlQZHc9PQ==--2a7f696a2cc1eae6c8514bf45305732d7ffb2252",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": true,
+        "tevo_section_name": "floor f"
+    },
+    {
+        "id": 544351186,
+        "url": "/ticket_groups/544351186",
+        "type": "event",
+        "row": "VIP",
+        "section": "VIP Soundcheck Package",
+        "quantity": 4,
+        "available_quantity": 4,
+        "wholesale_price": 1287.5,
+        "eticket": false,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": false,
+        "in_hand_on": "2019-06-11",
+        "remote_id": null,
+        "public_notes": "Will-Call, VIP Ticket in the Pit plus preshow soundcheck access and VIP Lounge access",
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-12-21T23:04:30Z",
+        "updated_at": "2018-12-21T23:04:30Z",
+        "splits": [
+            2,
+            4
+        ],
+        "ticket_states": {
+            "available": 4
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [],
+        "tickets": [
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 1287.5,
+        "format": "Physical",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 1250,
+        "ticket_costs": [
+            null,
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null,
+            null
+        ],
+        "freshness": "> 240 mins",
+        "signature": "SytaV08wdWZjWGh3dlRpSEhtN08zZE92anl3c3dCbHlFQ1BhQVhJTTA2bz0tLXFiaWpTNGQ3Rm8wZS91dGJ6Wi83enc9PQ==--d2fbb3ff13b7a9ac59ddcf779369365d05dea784",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "vip soundcheck package"
+    },
+    {
+        "id": 526251070,
+        "url": "/ticket_groups/526251070",
+        "type": "event",
+        "row": "PACKAGE",
+        "section": "STANDARD HOTEL",
+        "quantity": 4,
+        "available_quantity": 4,
+        "wholesale_price": 1339,
+        "eticket": false,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": false,
+        "in_hand_on": "2019-06-12",
+        "remote_id": null,
+        "public_notes": "Standard Hotel Package includes: Two night stay at a four star New York City property (check-in day before event, check-out day after event) | Premium reserved lower level (non-Floor) ticket located in the three sections closest to stage (orders of three or more may be split) | Private pre-show hospitality featuring food and drinks | Specially designed tour merchandise| Detailed itinerary | Additional hotel nights or specific days may be obtainable upon request | Rate is based on double occupancy | Orders for a quantity of one are subject to an additional charge |",
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-11-02T23:35:20Z",
+        "updated_at": "2018-12-23T11:16:48Z",
+        "splits": [
+            2,
+            4
+        ],
+        "ticket_states": {
+            "available": 4
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [],
+        "tickets": [
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 1339,
+        "format": "Physical",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 1300,
+        "ticket_costs": [
+            null,
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "R3BCeG5rUVhBaUFrK1pYNllSWXdmT1JXQ0ZISXRQUHUxTFZTNnlDeE83MD0tLThzeUgvc0F1MmJpSmdYOUN3WDJleUE9PQ==--baad05be3b2ac8c5e5f9e3626c2ab628168e791d",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": true,
+        "tevo_section_name": "standard hotel"
+    },
+    {
+        "id": 526278076,
+        "url": "/ticket_groups/526278076",
+        "type": "event",
+        "row": "PACKAGE",
+        "section": "STANDARD HOTEL",
+        "quantity": 4,
+        "available_quantity": 4,
+        "wholesale_price": 1339,
+        "eticket": false,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": false,
+        "in_hand_on": "2019-06-12",
+        "remote_id": null,
+        "public_notes": "Standard Hotel Package includes: Two night stay at a four star New York City property (check-in day before event, check-out day after event) | Premium reserved lower level (non-Floor) ticket located in the three sections closest to stage (orders of three or more may be split) | Private pre-show hospitality featuring food and drinks | Specially designed tour merchandise| Detailed itinerary | Additional hotel nights or specific days may be obtainable upon request | Rate is based on double occupancy | Orders for a quantity of one are subject to an additional charge |",
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-11-03T01:16:58Z",
+        "updated_at": "2018-12-23T12:56:36Z",
+        "splits": [
+            2,
+            4
+        ],
+        "ticket_states": {
+            "available": 4
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [
+            "29",
+            "26",
+            "27",
+            "28"
+        ],
+        "tickets": [
+            [
+                "available",
+                "29"
+            ],
+            [
+                "available",
+                "26"
+            ],
+            [
+                "available",
+                "27"
+            ],
+            [
+                "available",
+                "28"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 1339,
+        "format": "Physical",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 1300,
+        "ticket_costs": [
+            null,
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "NjdKNlliY00vZ253aVc1eDI5cHdMaTFTVlhMVERrdHFXaVpJS0RGaS93TT0tLTZsMFJVRHNDY09lRW1SNklyRFNKaFE9PQ==--7b05fc8678b121b0e76905b262c4cb04f9fd0827",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": true,
+        "tevo_section_name": "standard hotel"
+    },
+    {
+        "id": 542440270,
+        "url": "/ticket_groups/542440270",
+        "type": "event",
+        "row": "Package",
+        "section": "Gold-VIP",
+        "quantity": 24,
+        "available_quantity": 24,
+        "wholesale_price": 1411.1,
+        "eticket": false,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": false,
+        "in_hand_on": "2019-06-11",
+        "remote_id": null,
+        "public_notes": "Gold VIP Package includes: Premium reserved lower level (non-Floor) ticket located in the three sections closest to stage (orders of three or more may be split) | Luxurious seven hour limousine service (orders for a quantity of one are subject to an additional charge) | Private pre-show hospitality featuring food and drinks | Specially designed tour merchandise | Detailed itinerary |",
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-12-18T01:29:50Z",
+        "updated_at": "2018-12-23T12:56:11Z",
+        "splits": [
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18,
+            19,
+            20,
+            21,
+            22,
+            24
+        ],
+        "ticket_states": {
+            "available": 24
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [
+            "418",
+            "423",
+            "422",
+            "421",
+            "420",
+            "419",
+            "417",
+            "416",
+            "415",
+            "414",
+            "413",
+            "412",
+            "411",
+            "410",
+            "409",
+            "408",
+            "407",
+            "406",
+            "405",
+            "404",
+            "403",
+            "402",
+            "401",
+            "400"
+        ],
+        "tickets": [
+            [
+                "available",
+                "418"
+            ],
+            [
+                "available",
+                "423"
+            ],
+            [
+                "available",
+                "422"
+            ],
+            [
+                "available",
+                "421"
+            ],
+            [
+                "available",
+                "420"
+            ],
+            [
+                "available",
+                "419"
+            ],
+            [
+                "available",
+                "417"
+            ],
+            [
+                "available",
+                "416"
+            ],
+            [
+                "available",
+                "415"
+            ],
+            [
+                "available",
+                "414"
+            ],
+            [
+                "available",
+                "413"
+            ],
+            [
+                "available",
+                "412"
+            ],
+            [
+                "available",
+                "411"
+            ],
+            [
+                "available",
+                "410"
+            ],
+            [
+                "available",
+                "409"
+            ],
+            [
+                "available",
+                "408"
+            ],
+            [
+                "available",
+                "407"
+            ],
+            [
+                "available",
+                "406"
+            ],
+            [
+                "available",
+                "405"
+            ],
+            [
+                "available",
+                "404"
+            ],
+            [
+                "available",
+                "403"
+            ],
+            [
+                "available",
+                "402"
+            ],
+            [
+                "available",
+                "401"
+            ],
+            [
+                "available",
+                "400"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 1411.1,
+        "format": "Physical",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 1370,
+        "ticket_costs": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ],
+        "freshness": "< 30 mins",
+        "signature": "d3A5Nk1YYXBIS1k1TCtwUWxQdnFRemdPZGFvVmdwTXE4dkJIUDBWbkV6WT0tLWF5b0JqMC9Xbi9sdnU2VEdGV3dCL3c9PQ==--2d63f47cb36e6766d3830320485d1bdeaf1bc38a",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": true,
+        "tevo_section_name": "gold-vip"
+    },
+    {
+        "id": 526329565,
+        "url": "/ticket_groups/526329565",
+        "type": "event",
+        "row": "PACKAGE",
+        "section": "SWEETENER VIP",
+        "quantity": 8,
+        "available_quantity": 8,
+        "wholesale_price": 1854,
+        "eticket": false,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": false,
+        "in_hand_on": "2019-06-11",
+        "remote_id": null,
+        "public_notes": "Will-Call, VIP SWEETENER PACKAGE INCLUDES A PREMIUM TICKET PLUS ACCESS TO THE EXCLUSIVE SWEETENER VIP LOUNGE AND VIP GIFT BAG!",
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-11-03T03:39:27Z",
+        "updated_at": "2018-12-18T00:44:08Z",
+        "splits": [
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            8
+        ],
+        "ticket_states": {
+            "available": 8
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [],
+        "tickets": [
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 1854,
+        "format": "Physical",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 1800,
+        "ticket_costs": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ],
+        "freshness": "> 240 mins",
+        "signature": "RUNEN3pkdmhZRXpJVGFyclYxZmFWaSs3ckRyRnBDTGc2M2tYNjhLcDhIOD0tLXhrb1NIb1N0QzA4b0szUXU1RTQ0NXc9PQ==--396b34c107c16d78fa12e78dd2a3390797e020b9",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "sweetener vip"
+    },
+    {
+        "id": 527211091,
+        "url": "/ticket_groups/527211091",
+        "type": "event",
+        "row": "GREET PACKAGE",
+        "section": "VIP MEET",
+        "quantity": 4,
+        "available_quantity": 4,
+        "wholesale_price": 2667.7,
+        "eticket": false,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": false,
+        "in_hand_on": "2019-06-11",
+        "remote_id": null,
+        "public_notes": null,
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2018-11-05T23:24:08Z",
+        "updated_at": "2018-12-18T00:44:08Z",
+        "splits": [
+            2,
+            4
+        ],
+        "ticket_states": {
+            "available": 4
+        },
+        "ticket_hold_ids": [
+            "NULL",
+            "NULL",
+            "NULL",
+            "NULL"
+        ],
+        "seats": [],
+        "tickets": [
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ],
+            [
+                "available",
+                "NULL"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 2667.7,
+        "format": "Physical",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 2590,
+        "ticket_costs": [
+            null,
+            null,
+            null,
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null,
+            null,
+            null,
+            null
+        ],
+        "freshness": "> 240 mins",
+        "signature": "VmREWTRSbGwrbnVWb0xmWjVwTzNqMFByWElSQVg0T0FJN2V5QVJDejN4TT0tLXE5SzVISitsSzRrUVJGNE91bVM1UVE9PQ==--4487725eb4e0809c5d4edfacbe4f249879af1ecc",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "vip meet"
+    },
+    {
+        "id": 548276433,
+        "url": "/ticket_groups/548276433",
+        "type": "event",
+        "row": "SUITE",
+        "section": "LUXURY",
+        "quantity": 1,
+        "available_quantity": 1,
+        "wholesale_price": 13287,
+        "eticket": false,
+        "instant_delivery": false,
+        "intended_for_instant_delivery": false,
+        "in_hand": false,
+        "in_hand_on": "2019-06-16",
+        "remote_id": null,
+        "public_notes": "PRIVATE LUXURY SUITE IN A GREAT LOCATION - CALL FOR DETAILS",
+        "private_notes": null,
+        "exchange_notes": null,
+        "created_at": "2019-01-02T19:51:03Z",
+        "updated_at": "2019-01-02T19:51:03Z",
+        "splits": [
+            1
+        ],
+        "ticket_states": {
+            "available": 1
+        },
+        "ticket_hold_ids": [
+            "NULL"
+        ],
+        "seats": [],
+        "tickets": [
+            [
+                "available",
+                "NULL"
+            ]
+        ],
+        "has_spec_tickets": false,
+        "featured": false,
+        "retail_price": 13287,
+        "format": "Physical",
+        "face_value": null,
+        "view_type": null,
+        "broadcast": "t",
+        "wheelchair": false,
+        "evopay_discount": 0,
+        "evopay_discount_price": 12900,
+        "ticket_costs": [
+            null
+        ],
+        "ticket_purchase_order_ids": [
+            null
+        ],
+        "freshness": "< 90 mins",
+        "signature": "THJTdnVDdG43cUxqYytJT3Q1Q1lQQmdTQWxrVXFqZFhtRDE5RUd4cE9YRT0tLUhscjJFSE1TK3Z3UkpVcU1sK2cyd0E9PQ==--d904b8fb3d17b7e147069adb181ad4aa96229063",
+        "event": {
+            "id": 1591449,
+            "url": "/events/1591449",
+            "name": "Ariana Grande",
+            "occurs_at": "2019-06-18T19:00:00Z"
+        },
+        "office": {
+            "id": 1692,
+            "url": "/offices/1692",
+            "name": "Auto-Purchase",
+            "brokerage": {
+                "id": 1700,
+                "url": "/brokerages/1700",
+                "name": "Auto-Purchase",
+                "abbreviation": "TEvo Seller"
+            }
+        },
+        "natb_member": false,
+        "tevo_section_name": "luxury"
+    }
+]

--- a/src/ticketmap/index.js
+++ b/src/ticketmap/index.js
@@ -139,7 +139,7 @@ export default class TicketMap extends Component<*, State> {
       }
     })
 
-    for (const path of mapSvg.querySelectorAll('path[data-section-id]')) {
+    for (const path of mapSvg.querySelectorAll('*[data-section-id]')) {
       path.setAttribute('data-section-id', path.getAttribute('data-section-id').toLowerCase())
     }
 


### PR DESCRIPTION
The previous coloring fix assumed that all sections were `<path>` elements.