### PR TITLE
Synced initial ticketGroups with state

### DIFF
--- a/src/ticketmap/index.tsx
+++ b/src/ticketmap/index.tsx
@@ -131,7 +131,7 @@ export default class TicketMap extends Component<Props, State> {
       tooltipZoneId: '',
       tooltipX: 0,
       tooltipY: 0,
-      ticketGroups: []
+      ticketGroups: this.props.ticketGroups
     }
 
     this.publicApi = {


### PR DESCRIPTION
## Changelog
- set `TicketMap.state.ticketGroups` to `TicketMap.props.ticketGroups` on construction

## Motivation
If ticketgroups are supplied during construction and `updateTicketGroups` is never called, no tickets will be mapped to sections...