### PR TITLE
Moved dependencies to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,14 +17,6 @@
     "lint": "eslint . --cache",
     "fix": "yarn lint --fix"
   },
-  "dependencies": {
-    "preact": "8.4.2",
-    "preact-compat": "3.18.4",
-    "react-toggled": "1.2.7",
-    "reselect": "^4.0.0",
-    "svg-pan-zoom": "^3.6.0",
-    "unfetch": "^4.0.1"
-  },
   "devDependencies": {
     "@babel/core": "^7.2.0",
     "@babel/plugin-proposal-class-properties": "^7.2.1",
@@ -49,9 +41,15 @@
     "eslint-plugin-typescript": "^0.14.0",
     "html-loader": "0.5.5",
     "html-webpack-plugin": "3.2.0",
+    "preact": "^8.4.2",
+    "preact-compat": "3.18.4",
+    "react-toggled": "1.2.7",
+    "reselect": "^4.0.0",
     "style-loader": "^0.23.1",
     "stylelint": "^9.9.0",
     "stylelint-config-standard": "^18.2.0",
+    "svg-pan-zoom": "^3.6.0",
+    "unfetch": "^4.0.1",
     "url-loader": "^1.1.2",
     "webpack": "^4.27.1",
     "webpack-cli": "^3.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4984,7 +4984,7 @@ preact-transition-group@^1.1.1:
   resolved "https://registry.yarnpkg.com/preact-transition-group/-/preact-transition-group-1.1.1.tgz#f0a49327ea515ece34ea2be864c4a7d29e5d6e10"
   integrity sha1-8KSTJ+pRXs406ivoZMSn0p5dbhA=
 
-preact@8.4.2:
+preact@^8.4.2:
   version "8.4.2"
   resolved "https://registry.yarnpkg.com/preact/-/preact-8.4.2.tgz#1263b974a17d1ea80b66590e41ef786ced5d6a23"
   integrity sha512-TsINETWiisfB6RTk0wh3/mvxbGRvx+ljeBccZ4Z6MPFKgu/KFGyf2Bmw3Z/jlXhL5JlNKY6QAbA9PVyzIy9//A==


### PR DESCRIPTION
One of our dependents was noticing `peer dependency not met` errors due to this project's use of `preact`/`preact-compat`. This package technically has no dependencies as it exposes a compiled entrypoint. With this in mind, I moved the `dependencies` to `devDependencies` 