### PR TITLE
Refactored refs to use React.createRef

### DIFF
--- a/src/Actions/index.tsx
+++ b/src/Actions/index.tsx
@@ -23,7 +23,7 @@ interface State {
 }
 
 export default class Actions extends React.Component<Props & DefaultProps, State> {
-  container?: HTMLDivElement | null
+  container = React.createRef<HTMLDivElement>()
   mapZoom: any // eslint-disable-line @typescript-eslint/no-explicit-any
   timer?: number
 
@@ -80,11 +80,11 @@ export default class Actions extends React.Component<Props & DefaultProps, State
   }
 
   updateIsMobile = () => {
-    if (!this.container) {
+    if (!this.container.current) {
       return
     }
 
-    const isMobile = this.container.clientWidth < 700
+    const isMobile = this.container.current.clientWidth < 700
 
     if (this.state.isMobile !== isMobile) {
       this.setState({ isMobile })
@@ -95,7 +95,7 @@ export default class Actions extends React.Component<Props & DefaultProps, State
     const { isMobile } = this.state
 
     return (
-      <div style={this.styles.container} ref={ref => { this.container = ref }}>
+      <div style={this.styles.container} ref={this.container}>
         <ActionGroup>
           <Button
             data-rh='Default'

--- a/src/TicketMap/index.tsx
+++ b/src/TicketMap/index.tsx
@@ -50,7 +50,6 @@ class MapNotFoundError extends Error {
 
 export default class TicketMap extends Component<Props & DefaultProps, State> {
   publicApi: PublicApi
-  root = React.createRef<HTMLDivElement>()
   mapRoot = React.createRef<HTMLDivElement>()
 
   static defaultProps: DefaultProps = {
@@ -556,7 +555,6 @@ export default class TicketMap extends Component<Props & DefaultProps, State> {
 
     return (
       <div
-        ref={this.root}
         onMouseOver={this.onMouseOver}
         onTouchStart={this.onTouchStart}
         onMouseOut={this.onMouseOut}

--- a/src/Tooltip/index.tsx
+++ b/src/Tooltip/index.tsx
@@ -16,7 +16,7 @@ interface Props {
 }
 
 export default class Tooltip extends Component<Props> {
-  container!: HTMLElement
+  container = React.createRef<HTMLDivElement>()
 
   render () {
     const { isActive, ticketGroups, x, y, name, color } = this.props
@@ -35,19 +35,23 @@ export default class Tooltip extends Component<Props> {
       pointerEvents: 'none'
     }
 
+
     let renderAboveTarget = true
     let renderRightOfTarget = true
-    if (this.container && x !== undefined && y !== undefined) {
-      if (this.container.parentElement && x + this.container.clientWidth > this.container.parentElement.clientWidth) {
+
+    const container = this.container.current
+
+    if (container && x !== undefined && y !== undefined) {
+      if (container.parentElement && x + container.clientWidth > container.parentElement.clientWidth) {
         renderRightOfTarget = false
       }
 
-      if (y - this.container.clientHeight < 0) {
+      if (y - container.clientHeight < 0) {
         renderAboveTarget = false
       }
 
       if (renderAboveTarget) {
-        containerStyle.top = y - this.container.clientHeight
+        containerStyle.top = y - container.clientHeight
       } else {
         containerStyle.top = y
       }
@@ -55,7 +59,7 @@ export default class Tooltip extends Component<Props> {
       if (renderRightOfTarget) {
         containerStyle.left = x
       } else {
-        containerStyle.left = x - this.container.clientWidth
+        containerStyle.left = x - container.clientWidth
         containerStyle.alignItems = 'flex-end'
       }
     }
@@ -67,7 +71,7 @@ export default class Tooltip extends Component<Props> {
     }
 
     return (
-      <div ref={element => { this.container = element as HTMLElement }} style={containerStyle}>
+      <div ref={this.container} style={containerStyle}>
         {!renderAboveTarget && <div style={{
           ...tipStyle,
           borderWidth: renderRightOfTarget ? '10px 0 0 10px' : '0 0 10px 10px',

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -49,15 +49,12 @@ export default class SeatmapFactory {
       throw new Error('Seatmaps must be initialized with a DOM element.')
     }
 
-    let map!: TicketMap
+    let map = React.createRef<TicketMap>()
 
     render((
-      <TicketMap
-        {...this.configuration}
-        ref={(ref: TicketMap) => { map = ref }}
-      />
+      <TicketMap {...this.configuration} ref={map} />
     ), rootElement)
 
-    return map.publicApi
+    return map.current!.publicApi
   }
 }


### PR DESCRIPTION
## Motivation

Due to preact's [lack of `createRef` support](https://github.com/developit/preact-compat/issues/474), we were capturing element references using functions. The official React documentation describes `createRef` as the typical method of capturing references, so I've refactored the project to follow their guidance.

## Changlog

- refactored all "callback refs" into `createRef`s
- removed unnecessary ref from `TicketMap`