### PR TITLE
Pre: SEAT-291 Added showLegend to list of allowed config keys

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ticketevolution/seatmaps-client",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ticketevolution/seatmaps-client",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A client side JavaScript library that enables users to view interactive seating charts for tickets available via the Ticket Evolution API.",
   "keywords": [
     "Ticket Evolution",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -16,6 +16,7 @@ const optionalConfigKeys: (keyof DefaultProps)[] = [
   'sectionPercentiles',
   'mapsDomain',
   'showControls',
+  'showLegend',
   'mouseControlEnabled'
 ]
 


### PR DESCRIPTION
`showLegend` is a prop of `TicketMap`, but `SeatmapFactory` seems to be ignoring it. I've altered the set of optional config keys to allow `showLegend` to be passed to the React component.