### PR TITLE
SHEL-240 Disabled text selection

### DIFF
--- a/src/TicketMap/index.tsx
+++ b/src/TicketMap/index.tsx
@@ -490,7 +490,13 @@ export default class TicketMap extends Component<Props & DefaultProps, State> {
           fontFamily: this.props.mapFontFamily,
           height: '100%',
           width: '100%',
-          pointerEvents: this.props.mouseControlEnabled ? 'initial' : 'none'
+          pointerEvents: this.props.mouseControlEnabled ? 'initial' : 'none',
+          '-webkit-touch-callout': 'none',
+          '-webkit-user-select': 'none',
+          '-khtml-user-select': 'none',
+          '-moz-user-select': 'none',
+          '-ms-user-select': 'none',
+          'user-select': 'none'
         }}
       >
         <Tooltip


### PR DESCRIPTION
![Screen Shot 2019-06-19 at 12 09 33 PM](https://user-images.githubusercontent.com/5532165/59782422-ec0e9980-928b-11e9-8cb6-a08e0f734ec6.png)

During a different investigation, I noticed that certain mouse interactions would cause the text on the map (e.g., section names, button names) to become selected. This effect is clearly not intended, so I disabled it.