### PR TITLE
Adopted the project

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @ticketevolution/nomads
+*   @ticketevolution/enraged-titanium


### PR DESCRIPTION
The previous team is now defunct. Since ET now owns this project, the `CODEOWNERS` file should reflect that.