### PR TITLE
SEAT-277 - Zoom in and out buttons are not showing

### DIFF
--- a/src/Actions/index.tsx
+++ b/src/Actions/index.tsx
@@ -88,7 +88,8 @@ export default class Actions extends React.Component<
       return;
     }
 
-    const isMobile = currentContainer.clientWidth < 700;
+    const isMobile =
+      window.innerWidth < 520 || currentContainer.clientWidth < 400;
 
     if (this.state.isMobile !== isMobile) {
       this.setState({ isMobile });

--- a/src/__tests__/Actions/index.test.tsx
+++ b/src/__tests__/Actions/index.test.tsx
@@ -166,7 +166,7 @@ describe("Actions", () => {
       it("should set isMobile true if container width is mobile", () => {
         const getCurrentContainerMock = jest.fn();
         getCurrentContainerMock.mockReturnValue(({
-          clientWidth: 699,
+          clientWidth: 399,
         } as any) as HTMLDivElement);
         (wrapper.instance() as Actions).getCurrentContainer = getCurrentContainerMock;
         wrapper.instance().setState({ isMobile: false });
@@ -184,8 +184,53 @@ describe("Actions", () => {
       it("should set isMobile false if container width is not mobile", () => {
         const getCurrentContainerMock = jest.fn();
         getCurrentContainerMock.mockReturnValue(({
-          clientWidth: 700,
+          clientWidth: 400,
         } as any) as HTMLDivElement);
+        (wrapper.instance() as Actions).getCurrentContainer = getCurrentContainerMock;
+        jest.spyOn(wrapper.instance(), "setState");
+        wrapper.update();
+
+        (wrapper.instance() as Actions).updateIsMobile();
+
+        expect(getCurrentContainerMock).toHaveBeenCalledTimes(1);
+        expect(wrapper.instance().setState).toHaveBeenCalledWith({
+          isMobile: false,
+        });
+      });
+
+      it("should set isMobile true if window width is mobile", () => {
+        const getCurrentContainerMock = jest.fn();
+        getCurrentContainerMock.mockReturnValue(({
+          clientWidth: 400,
+        } as any) as HTMLDivElement);
+        Object.defineProperty(window, "innerWidth", {
+          writable: true,
+          configurable: true,
+          value: 519,
+        });
+        (wrapper.instance() as Actions).getCurrentContainer = getCurrentContainerMock;
+        wrapper.instance().setState({ isMobile: false });
+        jest.spyOn(wrapper.instance(), "setState");
+        wrapper.update();
+
+        (wrapper.instance() as Actions).updateIsMobile();
+
+        expect(getCurrentContainerMock).toHaveBeenCalledTimes(1);
+        expect(wrapper.instance().setState).toHaveBeenCalledWith({
+          isMobile: true,
+        });
+      });
+
+      it("should set isMobile false if container width is not mobile", () => {
+        const getCurrentContainerMock = jest.fn();
+        getCurrentContainerMock.mockReturnValue(({
+          clientWidth: 400,
+        } as any) as HTMLDivElement);
+        Object.defineProperty(window, "innerWidth", {
+          writable: true,
+          configurable: true,
+          value: 520,
+        });
         (wrapper.instance() as Actions).getCurrentContainer = getCurrentContainerMock;
         jest.spyOn(wrapper.instance(), "setState");
         wrapper.update();


### PR DESCRIPTION
In the latest version of the seatmaps lib the zoom in and out buttons are not showing even if the container has enough space to do it. The cause is that the lib is expecting a container of `700px` or wider.
![Core-LOCAL](https://user-images.githubusercontent.com/32183275/109296901-dc40aa00-780f-11eb-81cd-afe0d30a20ba.png)
