### PR TITLE
Ntrfcs 207 : Map legend open always for desktop

### DIFF
--- a/.changeset/light-suns-agree.md
+++ b/.changeset/light-suns-agree.md
@@ -1,0 +1,5 @@
+---
+"@ticketevolution/seatmaps-client": minor
+---
+
+Added showLegendOpenAlwaysForDesktop flag to always display the map legend on desktop when this flag is set to true.

--- a/packages/seatmaps-client/src/Actions/index.tsx
+++ b/packages/seatmaps-client/src/Actions/index.tsx
@@ -20,6 +20,7 @@ export interface Props {
 
 interface DefaultProps {
   showLegend: boolean;
+  showLegendOpenAlwaysForDesktop: boolean;
   showControls: boolean;
   onClearSelection(): void;
 }
@@ -43,6 +44,7 @@ export default class Actions extends React.Component<
 
   static defaultProps: DefaultProps = {
     showLegend: true,
+    showLegendOpenAlwaysForDesktop: false,
     showControls: true,
     onClearSelection: () => {},
   };
@@ -168,7 +170,7 @@ export default class Actions extends React.Component<
         )}
         {showRightActions && (
           <ActionGroup>
-            <Legend ranges={this.props.ranges} />
+            <Legend ranges={this.props.ranges} showLegendOpenAlwaysForDesktop={this.props.showLegendOpenAlwaysForDesktop}/>
           </ActionGroup>
         )}
       </div>

--- a/packages/seatmaps-client/src/Actions/index.tsx
+++ b/packages/seatmaps-client/src/Actions/index.tsx
@@ -170,7 +170,12 @@ export default class Actions extends React.Component<
         )}
         {showRightActions && (
           <ActionGroup>
-            <Legend ranges={this.props.ranges} showLegendOpenAlwaysForDesktop={this.props.showLegendOpenAlwaysForDesktop}/>
+            <Legend
+              ranges={this.props.ranges}
+              showLegendOpenAlwaysForDesktop={
+                this.props.showLegendOpenAlwaysForDesktop
+              }
+            />
           </ActionGroup>
         )}
       </div>

--- a/packages/seatmaps-client/src/Legend/index.tsx
+++ b/packages/seatmaps-client/src/Legend/index.tsx
@@ -30,7 +30,7 @@ interface State {
 export default class Legend extends Component<Props, State> {
   static defaultProps = {
     isMobile: false,
-    showLegendOpenAlwaysForDesktop: false
+    showLegendOpenAlwaysForDesktop: false,
   };
 
   state = {
@@ -41,40 +41,8 @@ export default class Legend extends Component<Props, State> {
     const { isOpen } = this.state;
     const { ranges, isMobile, showLegendOpenAlwaysForDesktop } = this.props;
 
-    return (
-      showLegendOpenAlwaysForDesktop && !isMobile? 
-        <div style={{ position: "relative" }}>
-          <div
-            style={{
-              position: "absolute",
-              backgroundColor: "white",
-              right: -2,
-              border: "2px solid lightgray",
-              borderRadius: "0 0 5px 5px",
-            }}
-          >
-            <h3 style={{ padding: "0 0 0 8px", textAlign: "left" }}>Map Legend</h3>
-            {ranges.map((range) => (
-              <div key={range.color} style={{ padding: 8, textAlign: "left" }}>
-                <Swatch color={range.color} style={{ marginRight: 8 }} />
-                <span>
-                  {formatCurrency(Math.floor(range.min))}
-                  {" - "}
-                  {formatCurrency(Math.ceil(range.max))}
-                </span>
-              </div>
-            ))}
-          </div>
-        </div>
-      :
+    return showLegendOpenAlwaysForDesktop && !isMobile ? (
       <div style={{ position: "relative" }}>
-      <Button
-        onClick={() => this.setState({ isOpen: !isOpen })}
-        icon={isOpen ? <IconChevronUp /> : <IconChevronDown />}
-        text={`${isOpen ? "Hide " : "Show "}Map Legend`}
-        isMobile={isMobile}
-      />
-      {ranges.length > 0 && isOpen && (
         <div
           style={{
             position: "absolute",
@@ -84,6 +52,9 @@ export default class Legend extends Component<Props, State> {
             borderRadius: "0 0 5px 5px",
           }}
         >
+          <h3 style={{ padding: "0 0 0 8px", textAlign: "left" }}>
+            Map Legend
+          </h3>
           {ranges.map((range) => (
             <div key={range.color} style={{ padding: 8, textAlign: "left" }}>
               <Swatch color={range.color} style={{ marginRight: 8 }} />
@@ -95,8 +66,38 @@ export default class Legend extends Component<Props, State> {
             </div>
           ))}
         </div>
-      )}
-    </div>
+      </div>
+    ) : (
+      <div style={{ position: "relative" }}>
+        <Button
+          onClick={() => this.setState({ isOpen: !isOpen })}
+          icon={isOpen ? <IconChevronUp /> : <IconChevronDown />}
+          text={`${isOpen ? "Hide " : "Show "}Map Legend`}
+          isMobile={isMobile}
+        />
+        {ranges.length > 0 && isOpen && (
+          <div
+            style={{
+              position: "absolute",
+              backgroundColor: "white",
+              right: -2,
+              border: "2px solid lightgray",
+              borderRadius: "0 0 5px 5px",
+            }}
+          >
+            {ranges.map((range) => (
+              <div key={range.color} style={{ padding: 8, textAlign: "left" }}>
+                <Swatch color={range.color} style={{ marginRight: 8 }} />
+                <span>
+                  {formatCurrency(Math.floor(range.min))}
+                  {" - "}
+                  {formatCurrency(Math.ceil(range.max))}
+                </span>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
     );
   }
 }

--- a/packages/seatmaps-client/src/Legend/index.tsx
+++ b/packages/seatmaps-client/src/Legend/index.tsx
@@ -20,6 +20,7 @@ export interface Range {
 export interface Props {
   ranges: Range[];
   isMobile?: boolean;
+  showLegendOpenAlwaysForDesktop?: boolean;
 }
 
 interface State {
@@ -29,6 +30,7 @@ interface State {
 export default class Legend extends Component<Props, State> {
   static defaultProps = {
     isMobile: false,
+    showLegendOpenAlwaysForDesktop: false
   };
 
   state = {
@@ -37,17 +39,11 @@ export default class Legend extends Component<Props, State> {
 
   render() {
     const { isOpen } = this.state;
-    const { ranges, isMobile } = this.props;
+    const { ranges, isMobile, showLegendOpenAlwaysForDesktop } = this.props;
 
     return (
-      <div style={{ position: "relative" }}>
-        <Button
-          onClick={() => this.setState({ isOpen: !isOpen })}
-          icon={isOpen ? <IconChevronUp /> : <IconChevronDown />}
-          text={`${isOpen ? "Hide " : "Show "}Map Legend`}
-          isMobile={isMobile}
-        />
-        {ranges.length > 0 && isOpen && (
+      showLegendOpenAlwaysForDesktop && !isMobile? 
+        <div style={{ position: "relative" }}>
           <div
             style={{
               position: "absolute",
@@ -57,6 +53,7 @@ export default class Legend extends Component<Props, State> {
               borderRadius: "0 0 5px 5px",
             }}
           >
+            <h3 style={{ padding: "0 0 0 8px", textAlign: "left" }}>Map Legend</h3>
             {ranges.map((range) => (
               <div key={range.color} style={{ padding: 8, textAlign: "left" }}>
                 <Swatch color={range.color} style={{ marginRight: 8 }} />
@@ -68,8 +65,38 @@ export default class Legend extends Component<Props, State> {
               </div>
             ))}
           </div>
-        )}
-      </div>
+        </div>
+      :
+      <div style={{ position: "relative" }}>
+      <Button
+        onClick={() => this.setState({ isOpen: !isOpen })}
+        icon={isOpen ? <IconChevronUp /> : <IconChevronDown />}
+        text={`${isOpen ? "Hide " : "Show "}Map Legend`}
+        isMobile={isMobile}
+      />
+      {ranges.length > 0 && isOpen && (
+        <div
+          style={{
+            position: "absolute",
+            backgroundColor: "white",
+            right: -2,
+            border: "2px solid lightgray",
+            borderRadius: "0 0 5px 5px",
+          }}
+        >
+          {ranges.map((range) => (
+            <div key={range.color} style={{ padding: 8, textAlign: "left" }}>
+              <Swatch color={range.color} style={{ marginRight: 8 }} />
+              <span>
+                {formatCurrency(Math.floor(range.min))}
+                {" - "}
+                {formatCurrency(Math.ceil(range.max))}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
     );
   }
 }

--- a/packages/seatmaps-client/src/TicketMap/index.tsx
+++ b/packages/seatmaps-client/src/TicketMap/index.tsx
@@ -669,7 +669,7 @@ export class TicketMap extends Component<Props & DefaultProps, State> {
             onClearSelection={this.clearSelection}
             ranges={$costRanges(this.state, this.props)}
             showLegend={this.props.showLegend}
-            showLegendOpenAlwaysForDesktop={true}
+            showLegendOpenAlwaysForDesktop={this.props.showLegendOpenAlwaysForDesktop}
             showControls={this.props.showControls}
             onZoomIn={this.handleZoomIn}
             onZoomOut={this.handleZoomOut}

--- a/packages/seatmaps-client/src/TicketMap/index.tsx
+++ b/packages/seatmaps-client/src/TicketMap/index.tsx
@@ -669,7 +669,9 @@ export class TicketMap extends Component<Props & DefaultProps, State> {
             onClearSelection={this.clearSelection}
             ranges={$costRanges(this.state, this.props)}
             showLegend={this.props.showLegend}
-            showLegendOpenAlwaysForDesktop={this.props.showLegendOpenAlwaysForDesktop}
+            showLegendOpenAlwaysForDesktop={
+              this.props.showLegendOpenAlwaysForDesktop
+            }
             showControls={this.props.showControls}
             onZoomIn={this.handleZoomIn}
             onZoomOut={this.handleZoomOut}

--- a/packages/seatmaps-client/src/TicketMap/index.tsx
+++ b/packages/seatmaps-client/src/TicketMap/index.tsx
@@ -67,6 +67,7 @@ export class TicketMap extends Component<Props & DefaultProps, State> {
     },
     ticketGroups: [],
     showLegend: true,
+    showLegendOpenAlwaysForDesktop: false,
     showControls: true,
     mouseControlEnabled: true,
     showZoomHelper: true,
@@ -668,6 +669,7 @@ export class TicketMap extends Component<Props & DefaultProps, State> {
             onClearSelection={this.clearSelection}
             ranges={$costRanges(this.state, this.props)}
             showLegend={this.props.showLegend}
+            showLegendOpenAlwaysForDesktop={true}
             showControls={this.props.showControls}
             onZoomIn={this.handleZoomIn}
             onZoomOut={this.handleZoomOut}

--- a/packages/seatmaps-client/src/__tests__/Actions/__snapshots__/index.test.tsx.snap
+++ b/packages/seatmaps-client/src/__tests__/Actions/__snapshots__/index.test.tsx.snap
@@ -9,6 +9,7 @@ exports[`Actions when controls are visible on desktop browsers matches snapshot 
   ranges={[]}
   showControls={true}
   showLegend={true}
+  showLegendOpenAlwaysForDesktop={false}
 >
   <div
     data-testid="seatmaps-actions-menu"
@@ -251,6 +252,7 @@ exports[`Actions when controls are visible on desktop browsers matches snapshot 
         <Legend
           isMobile={false}
           ranges={[]}
+          showLegendOpenAlwaysForDesktop={false}
         >
           <div
             style={
@@ -314,6 +316,7 @@ exports[`Actions when controls are visible on mobile browsers matches snapshot 1
   ranges={[]}
   showControls={true}
   showLegend={true}
+  showLegendOpenAlwaysForDesktop={false}
 >
   <div
     data-testid="seatmaps-actions-menu"
@@ -556,6 +559,7 @@ exports[`Actions when controls are visible on mobile browsers matches snapshot 1
         <Legend
           isMobile={false}
           ranges={[]}
+          showLegendOpenAlwaysForDesktop={false}
         >
           <div
             style={

--- a/packages/seatmaps-client/src/index.tsx
+++ b/packages/seatmaps-client/src/index.tsx
@@ -23,6 +23,7 @@ const optionalConfigKeys: (keyof DefaultProps)[] = [
   "sectionPercentiles",
   "mapsDomain",
   "showControls",
+  "showLegendOpenAlwaysForDesktop",
   "showLegend",
   "mouseControlEnabled",
   "showZoomHelper",

--- a/packages/seatmaps-client/src/types/TicketMap.ts
+++ b/packages/seatmaps-client/src/types/TicketMap.ts
@@ -37,7 +37,7 @@ export interface DefaultProps {
   mapsDomain: string;
   onSelection(sections: string[]): void;
   showControls: boolean;
-  showLegendOpenAlwaysForDesktop: boolean,
+  showLegendOpenAlwaysForDesktop: boolean;
   mouseControlEnabled: boolean;
   showZoomHelper: boolean;
   missingSeatMapLogo?: React.ReactNode;

--- a/packages/seatmaps-client/src/types/TicketMap.ts
+++ b/packages/seatmaps-client/src/types/TicketMap.ts
@@ -37,6 +37,7 @@ export interface DefaultProps {
   mapsDomain: string;
   onSelection(sections: string[]): void;
   showControls: boolean;
+  showLegendOpenAlwaysForDesktop: boolean,
   mouseControlEnabled: boolean;
   showZoomHelper: boolean;
   missingSeatMapLogo?: React.ReactNode;


### PR DESCRIPTION
Jira: [NTRFCS-207](https://ticketevolution.atlassian.net/browse/NTRFCS-207)

> [!IMPORTANT]
> Toggle to **Squash and Merge** when merging PRs to `staging` branch

## What
This PR adds/removes/fixes&hellip;

## Testing

I tested this code by manually;

## Extras
- [ ] Includes a DB migration
- [ ] After merge, requires local environment changes like running `bin/build`, `.env` changes etc.
- [x] Includes UI Changes: add screenshots or videos

_(if any are checked, please describe below)_
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/9832ba0f-86cc-443d-911c-e4b90f009b54" />


## PR Code Coverage

- Changeset: XX%
- Overall: XX%

Measure with `bin/test_cov` or some other means. You can find html coverage levels in `coverage/index.html` or in `stdout`.

After a successful test run, you can also see calculated and merged coverage, per branch, on [Grafana](https://grafana.tevo.com/d/6r9OX0y7k/code-coverage?orgId=1)


[NTRFCS-207]: https://ticketevolution.atlassian.net/browse/NTRFCS-207?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ